### PR TITLE
Add Linux ARM64 prebuilds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
   linux:
     strategy:
       matrix:
-        arch: ['ia32', 'x64']
+        arch: ['arm64', 'ia32', 'x64']
     runs-on: ubuntu-latest
     container:
       # using oldest image to ensure support for older glibc


### PR DESCRIPTION
In our efforts to migrate to Linux ARM64 instances, we'd love to have Linux ARM64 support for `@datadog/pprof`, this MR is a tentative enhancement for that.

Signed-off-by: Adrien Fillon <adrien.fillon@manomano.com>