### PR TITLE
fix support for old glibc and add support for linux arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,22 +29,38 @@ env:
   TARGET_NAME: ${{ inputs.target-name }}
 
 jobs:
-  linux:
-    strategy:
-      matrix:
-        arch: ['ia32', 'x64']
+  linux-ia32:
+    runs-on: ubuntu-latest
+    name: linux-ia32
+    env:
+      ARCH: ia32
+      DOCKER_BUILDER: rochdev/holy-node-box:12-i386
+    steps:
+      - uses: docker/setup-qemu-action@v2
+      - uses: actions/checkout@v3
+      - uses: DataDog/action-prebuildify/prebuild@glibcxx-3.4.17
+
+  linux-x64:
     runs-on: ubuntu-latest
     container:
-      # using oldest image to ensure support for older glibc
-      # from node:12.0.0 on 2021-08-30
-      image: node@sha256:c88ef4f7ca8d52ed50366d821e104d029f43e8686120a29541ce0371f333453f
-    name: linux-${{ matrix.arch }}
+      image: rochdev/holy-node-box:12-amd64
+    name: linux-x64
     env:
-      ARCH: ${{ matrix.arch }}
+      ARCH: x64
     steps:
-      - run: apt-get update && apt-get install -y g++-multilib
       - uses: actions/checkout@v3
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@glibcxx-3.4.17
+
+  linux-arm64:
+    runs-on: ubuntu-latest
+    name: linux-arm64
+    env:
+      ARCH: arm64
+      DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8
+    steps:
+      - uses: docker/setup-qemu-action@v2
+      - uses: actions/checkout@v3
+      - uses: DataDog/action-prebuildify/prebuild@glibcxx-3.4.17
 
   macos-apple:
     runs-on: macos-11
@@ -85,7 +101,7 @@ jobs:
     strategy:
       matrix:
         node: [12, 14, 16, 18]
-    needs: linux
+    needs: linux-x64
     runs-on: ubuntu-latest
     container:
       image: node:${{ matrix.node }}-alpine
@@ -96,7 +112,7 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   linux-test:
-    needs: linux
+    needs: linux-x64
     runs-on: ubuntu-latest
     name: linux-test
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: docker/setup-qemu-action@v2
       - uses: actions/checkout@v3
-      - uses: DataDog/action-prebuildify/prebuild@glibcxx-3.4.17
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-x64:
     runs-on: ubuntu-latest
@@ -49,7 +49,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v3
-      - uses: DataDog/action-prebuildify/prebuild@glibcxx-3.4.17
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-arm64:
     runs-on: ubuntu-latest
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: docker/setup-qemu-action@v2
       - uses: actions/checkout@v3
-      - uses: DataDog/action-prebuildify/prebuild@glibcxx-3.4.17
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   macos-apple:
     runs-on: macos-11

--- a/prebuild/action.yml
+++ b/prebuild/action.yml
@@ -4,6 +4,17 @@ runs:
     - run: $PACKAGE_MANAGER install --ignore-scripts
       shell: bash
     - run: yarn exec node $GITHUB_ACTION_PATH
+      if: ${{ env.DOCKER_BUILDER == '' }}
+      shell: bash
+    - run: |
+        docker run \
+          -v $GITHUB_ACTION_PATH:/usr/action \
+          -v $PWD:/usr/workspace \
+          -e TARGET_NAME=$TARGET_NAME \
+          -w /usr/action \
+          $DOCKER_BUILDER \
+          /bin/bash -c 'yarn && cd /usr/workspace && yarn exec node /usr/action'
+      if: ${{ env.DOCKER_BUILDER != '' }}
       shell: bash
     - uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
This PR fixes support for GLIBC down to 2.17 and GLIBCXX 3.4.17 which are the minimum supported by Node by using a custom Docker image based on Centos 7. It also adds support for Linux ARM64 by using QEMU and the ARM64 version of that same image.

Some CI jobs are either failing or using the wrong architecture but that's because they are using the actions from the `main` branch instead of this branch for the merge. An actual passing run can be seen [here](https://github.com/DataDog/action-prebuildify/actions/runs/2539835606). The centos7 job was just a test and is safe to ignore.