### PR TITLE
add support for node 19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
   alpine-test:
     strategy:
       matrix:
-        node: [12, 14, 16, 18]
+        node: [12, 14, 16, 18, 19]
     needs: linux-x64
     runs-on: ubuntu-latest
     container:
@@ -129,6 +129,8 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
       - uses: DataDog/action-prebuildify/node/18@main
       - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/node/19@main
+      - uses: DataDog/action-prebuildify/test@main
 
   macos-x64-test:
     needs: macos
@@ -144,6 +146,8 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
       - uses: DataDog/action-prebuildify/node/18@main
       - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/node/19@main
+      - uses: DataDog/action-prebuildify/test@main
 
   windows-test:
     needs: windows
@@ -158,4 +162,6 @@ jobs:
       - uses: DataDog/action-prebuildify/node/16@main
       - uses: DataDog/action-prebuildify/test@main
       - uses: DataDog/action-prebuildify/node/18@main
+      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/node/19@main
       - uses: DataDog/action-prebuildify/test@main

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ GitHub Actions reusable workflow to generate prebuilds for a Node native add-on.
 
 ## Usage
 
-This workflow can be used to generate Node 12 - 18 prebuilds for Linux, macOS
+This workflow can be used to generate Node 12 - 19 prebuilds for Linux, macOS
 and Windows. The prebuilds will be stored in the `prebuilds` folder which should
 be added to `.gitignore`, and can be loaded using
 [node-gyp-build](https://www.npmjs.com/package/node-gyp-build) with

--- a/binding.gyp
+++ b/binding.gyp
@@ -10,7 +10,7 @@
     "xcode_settings": {
       "MACOSX_DEPLOYMENT_TARGET": "10.10",
       "OTHER_CFLAGS": [
-        "-std=c++14",
+        "-std=c++17",
         "-stdlib=libc++",
         "-Wall"
       ]

--- a/node/19/action.yml
+++ b/node/19/action.yml
@@ -1,0 +1,8 @@
+name: Node 19
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '19'
+        cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "node test"
   },
   "dependencies": {
-    "nan": "^2.15.0",
+    "nan": "^2.17.0",
     "node-gyp-build": "^3.9.0"
   },
   "devDependencies": {

--- a/prebuild/index.js
+++ b/prebuild/index.js
@@ -19,7 +19,8 @@ const targets = [
   { version: '15.0.0', abi: '88' },
   { version: '16.0.0', abi: '93' },
   { version: '17.0.1', abi: '102' },
-  { version: '18.0.0', abi: '108' }
+  { version: '18.0.0', abi: '108' },
+  { version: '19.0.0', abi: '111' }
 ].filter(target => semver.satisfies(target.version, NODE_VERSIONS))
 
 prebuildify()

--- a/yarn.lock
+++ b/yarn.lock
@@ -906,10 +906,10 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nan@^2.15.0:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
-  integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
+nan@^2.17.0:
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.17.0.tgz#c0150a2368a182f033e9aa5195ec76ea41a199cb"
+  integrity sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
The workflow fails because the actions don't exist on `main` yet. A workflow running the actions on the branch directly can be seen passing here: https://github.com/DataDog/action-prebuildify/actions/runs/3332749363