### PR TITLE
update prebuild action to download artifacts before building

### DIFF
--- a/prebuild/action.yml
+++ b/prebuild/action.yml
@@ -1,6 +1,7 @@
 runs:
   using: composite
   steps:
+    - uses: actions/download-artifact@v3
     - run: $PACKAGE_MANAGER install --ignore-scripts
       shell: bash
     - run: yarn exec node $GITHUB_ACTION_PATH


### PR DESCRIPTION
This allows the parent workflow to upload additional library files as artifacts so that they can later be used in `binding.gyp`.