### PR TITLE
add linux musl prebuild and prebuild/postbuild scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,11 @@ on:
         default: ''
         required: false
         type: string
+      prebuild:
+        description: Command to run before prebuilds are generated.
+        default: ''
+        required: false
+        type: string
       skip:
         description: List of jobs to skip.
         default: ''
@@ -43,6 +48,7 @@ env:
   NAPI: ${{ inputs.napi }}
   PACKAGE_MANAGER: ${{ inputs.package-manager }}
   POSTBUILD: ${{ inputs.postbuild }}
+  PREBUILD: ${{ inputs.prebuild }}
   TARGET_NAME: ${{ inputs.target-name }}
 
 jobs:
@@ -102,6 +108,24 @@ jobs:
           submodules: true
       - uses: DataDog/action-prebuildify/prebuild@main
 
+  linuxmusl-x64:
+    if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
+    runs-on: ubuntu-latest
+    container:
+      image: node:12.0.0-alpine
+    name: linuxmusl-x64
+    env:
+      ARCH: x64
+      LIBC: musl
+    steps:
+      - run: apk update && apk add bash build-base git python
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: DataDog/action-prebuildify/prebuild@main
+
+  # TODO: linuxmusl-arm / linuxmusl-arm64
+
   macos:
     strategy:
       matrix:
@@ -138,7 +162,7 @@ jobs:
     strategy:
       matrix:
         node: [12, 14, 16, 18, 19]
-    needs: linux-x64
+    needs: linuxmusl-x64
     runs-on: ubuntu-latest
     container:
       image: node:${{ matrix.node }}-alpine

--- a/prebuild/action.yml
+++ b/prebuild/action.yml
@@ -11,15 +11,14 @@ runs:
         docker run \
           -v $GITHUB_ACTION_PATH:/usr/action \
           -v $PWD:/usr/workspace \
-          -e NAPI=$NAPI \
-          -e TARGET_NAME=$TARGET_NAME \
+          -e NAPI="$NAPI" \
+          -e POSTBUILD="$POSTBUILD" \
+          -e PREBUILD="$PREBUILD" \
+          -e TARGET_NAME="$TARGET_NAME" \
           -w /usr/action \
           $DOCKER_BUILDER \
           /bin/bash -c 'yarn && cd /usr/workspace && yarn exec node /usr/action'
       if: ${{ env.DOCKER_BUILDER != '' }}
-      shell: bash
-    - run: eval $POSTBUILD
-      if: ${{ env.POSTBUILD != '' }}
       shell: bash
     - uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
Some addons need to be built explicitly with MUSL to work properly. Right now this only adds support for x64, but that's already an improvement since otherwise such an addon would fail regardless of the architecture.