### PR TITLE
Add a feature to build for a NAPI-RS project

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   linux-x64:
     if: ${{ !contains(inputs.skip, 'linux-x64') }}
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   linux-arm64:
     if: ${{ !contains(inputs.skip, 'linux-arm64') }}
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   linux-arm:
     if: ${{ !contains(inputs.skip, 'linux-arm') }}
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   linuxmusl-x64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
@@ -134,7 +134,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
 
@@ -151,7 +151,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   windows:
     strategy:
@@ -166,7 +166,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   # Tests
 
@@ -184,7 +184,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
 
   linux-test:
     needs: linux-x64
@@ -195,15 +195,15 @@ jobs:
         with:
           submodules: true
       - uses: DataDog/action-prebuildify/node/12@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/14@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/16@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/18@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/19@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
 
   macos-x64-test:
     needs: macos
@@ -214,15 +214,15 @@ jobs:
         with:
           submodules: true
       - uses: DataDog/action-prebuildify/node/12@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/14@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/16@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/18@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/19@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
 
   windows-test:
     needs: windows
@@ -233,12 +233,12 @@ jobs:
         with:
           submodules: true
       - uses: DataDog/action-prebuildify/node/12@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/14@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/16@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/18@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/19@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,16 @@ on:
         default: addon
         required: false
         type: string
+      napi-rs:
+        description: Whether or not this build is for a napi-rs project.
+        default: false
+        required: false
+        type: string
+      directory-path:
+        description: The path to the directory containing your build files, relative to the repo root.
+        default: '.'
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
@@ -50,6 +60,8 @@ env:
   POSTBUILD: ${{ inputs.postbuild }}
   PREBUILD: ${{ inputs.prebuild }}
   TARGET_NAME: ${{ inputs.target-name }}
+  NAPI_RS: ${{ inputs.napi-rs }}
+  DIRECTORY_PATH: ${{ inputs.directory-path }}
 
 jobs:
   linux-ia32:
@@ -64,7 +76,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   linux-x64:
     if: ${{ !contains(inputs.skip, 'linux-x64') }}
@@ -78,7 +90,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   linux-arm64:
     if: ${{ !contains(inputs.skip, 'linux-arm64') }}
@@ -92,7 +104,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   linux-arm:
     if: ${{ !contains(inputs.skip, 'linux-arm') }}
@@ -106,7 +118,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   linuxmusl-x64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
@@ -122,7 +134,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
 
@@ -139,7 +151,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   windows:
     strategy:
@@ -154,11 +166,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   # Tests
 
   alpine-test:
+    if: inputs.napi-rs == false
     strategy:
       matrix:
         node: [12, 14, 16, 18, 19]
@@ -175,6 +188,7 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   linux-test:
+    if: inputs.napi-rs == false
     needs: linux-x64
     runs-on: ubuntu-latest
     name: linux-test
@@ -194,6 +208,7 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   macos-x64-test:
+    if: inputs.napi-rs == false
     needs: macos
     runs-on: macos-11
     name: macos-x64-test
@@ -213,6 +228,7 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   windows-test:
+    if: inputs.napi-rs == false
     needs: windows
     runs-on: windows-2019
     name: windows-test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,7 +171,7 @@ jobs:
   # Tests
 
   alpine-test:
-    if: ${{ inputs.napi-rs == false }}
+    if: ${{ inputs.napi-rs == 'false' }}
     strategy:
       matrix:
         node: [12, 14, 16, 18, 19]
@@ -188,7 +188,7 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   linux-test:
-    if: ${{ inputs.napi-rs == false }}
+    if: ${{ inputs.napi-rs == 'false' }}
     needs: linux-x64
     runs-on: ubuntu-latest
     name: linux-test
@@ -208,7 +208,7 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   macos-x64-test:
-    if: ${{ inputs.napi-rs == false }}
+    if: ${{ inputs.napi-rs == 'false' }}
     needs: macos
     runs-on: macos-11
     name: macos-x64-test
@@ -228,7 +228,7 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   windows-test:
-    if: ${{ inputs.napi-rs == false }}
+    if: ${{ inputs.napi-rs == 'false' }}
     needs: windows
     runs-on: windows-2019
     name: windows-test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,6 +171,7 @@ jobs:
   # Tests
 
   alpine-test:
+    if: ${{ !input.napi-rs }}
     strategy:
       matrix:
         node: [12, 14, 16, 18, 19]
@@ -187,6 +188,7 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   linux-test:
+    if: ${{ !input.napi-rs }}
     needs: linux-x64
     runs-on: ubuntu-latest
     name: linux-test
@@ -206,6 +208,7 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   macos-x64-test:
+    if: ${{ !input.napi-rs }}
     needs: macos
     runs-on: macos-11
     name: macos-x64-test
@@ -225,6 +228,7 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   windows-test:
+    if: ${{ !input.napi-rs }}
     needs: windows
     runs-on: windows-2019
     name: windows-test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,7 +184,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
 
   linux-test:
     needs: linux-x64
@@ -195,15 +195,15 @@ jobs:
         with:
           submodules: true
       - uses: DataDog/action-prebuildify/node/12@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/14@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/16@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/18@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/19@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
 
   macos-x64-test:
     needs: macos
@@ -214,15 +214,15 @@ jobs:
         with:
           submodules: true
       - uses: DataDog/action-prebuildify/node/12@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/14@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/16@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/18@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/19@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
 
   windows-test:
     needs: windows
@@ -233,12 +233,12 @@ jobs:
         with:
           submodules: true
       - uses: DataDog/action-prebuildify/node/12@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/14@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/16@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/18@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/19@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-x64:
     if: ${{ !contains(inputs.skip, 'linux-x64') }}
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-arm64:
     if: ${{ !contains(inputs.skip, 'linux-arm64') }}
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-arm:
     if: ${{ !contains(inputs.skip, 'linux-arm') }}
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxmusl-x64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
@@ -134,7 +134,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
 
@@ -151,7 +151,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   windows:
     strategy:
@@ -166,7 +166,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # Tests
 
@@ -184,7 +184,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/test@main
 
   linux-test:
     needs: linux-x64
@@ -195,15 +195,15 @@ jobs:
         with:
           submodules: true
       - uses: DataDog/action-prebuildify/node/12@main
-      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/test@main
       - uses: DataDog/action-prebuildify/node/14@main
-      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/test@main
       - uses: DataDog/action-prebuildify/node/16@main
-      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/test@main
       - uses: DataDog/action-prebuildify/node/18@main
-      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/test@main
       - uses: DataDog/action-prebuildify/node/19@main
-      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/test@main
 
   macos-x64-test:
     needs: macos
@@ -214,15 +214,15 @@ jobs:
         with:
           submodules: true
       - uses: DataDog/action-prebuildify/node/12@main
-      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/test@main
       - uses: DataDog/action-prebuildify/node/14@main
-      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/test@main
       - uses: DataDog/action-prebuildify/node/16@main
-      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/test@main
       - uses: DataDog/action-prebuildify/node/18@main
-      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/test@main
       - uses: DataDog/action-prebuildify/node/19@main
-      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/test@main
 
   windows-test:
     needs: windows
@@ -233,12 +233,12 @@ jobs:
         with:
           submodules: true
       - uses: DataDog/action-prebuildify/node/12@main
-      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/test@main
       - uses: DataDog/action-prebuildify/node/14@main
-      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/test@main
       - uses: DataDog/action-prebuildify/node/16@main
-      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/test@main
       - uses: DataDog/action-prebuildify/node/18@main
-      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/test@main
       - uses: DataDog/action-prebuildify/node/19@main
-      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/test@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,6 +171,7 @@ jobs:
   # Tests
 
   alpine-test:
+    if: ${{ inputs.napi-rs == false }}
     strategy:
       matrix:
         node: [12, 14, 16, 18, 19]
@@ -187,6 +188,7 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   linux-test:
+    if: ${{ inputs.napi-rs == false }}
     needs: linux-x64
     runs-on: ubuntu-latest
     name: linux-test
@@ -206,6 +208,7 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   macos-x64-test:
+    if: ${{ inputs.napi-rs == false }}
     needs: macos
     runs-on: macos-11
     name: macos-x64-test
@@ -225,6 +228,7 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   windows-test:
+    if: ${{ inputs.napi-rs == false }}
     needs: windows
     runs-on: windows-2019
     name: windows-test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
       ARCH: x64
       LIBC: musl
     steps:
-      - run: apk update && apk add bash build-base git python
+      - run: apk update && apk add bash build-base git python curl
       - uses: actions/checkout@v3
         with:
           submodules: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,7 +171,6 @@ jobs:
   # Tests
 
   alpine-test:
-    if: ${{ !inputs.napi-rs }}
     strategy:
       matrix:
         node: [12, 14, 16, 18, 19]
@@ -188,7 +187,6 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   linux-test:
-    if: ${{ !inputs.napi-rs }}
     needs: linux-x64
     runs-on: ubuntu-latest
     name: linux-test
@@ -208,7 +206,6 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   macos-x64-test:
-    if: ${{ !inputs.napi-rs }}
     needs: macos
     runs-on: macos-11
     name: macos-x64-test
@@ -228,7 +225,6 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   windows-test:
-    if: ${{ !inputs.napi-rs }}
     needs: windows
     runs-on: windows-2019
     name: windows-test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,7 +171,6 @@ jobs:
   # Tests
 
   alpine-test:
-    if: ${{ inputs.napi-rs == 'false' }}
     strategy:
       matrix:
         node: [12, 14, 16, 18, 19]
@@ -185,10 +184,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
 
   linux-test:
-    if: ${{ inputs.napi-rs == 'false' }}
     needs: linux-x64
     runs-on: ubuntu-latest
     name: linux-test
@@ -197,18 +195,17 @@ jobs:
         with:
           submodules: true
       - uses: DataDog/action-prebuildify/node/12@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/14@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/16@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/18@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/19@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
 
   macos-x64-test:
-    if: ${{ inputs.napi-rs == 'false' }}
     needs: macos
     runs-on: macos-11
     name: macos-x64-test
@@ -217,18 +214,17 @@ jobs:
         with:
           submodules: true
       - uses: DataDog/action-prebuildify/node/12@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/14@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/16@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/18@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/19@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
 
   windows-test:
-    if: ${{ inputs.napi-rs == 'false' }}
     needs: windows
     runs-on: windows-2019
     name: windows-test
@@ -237,12 +233,12 @@ jobs:
         with:
           submodules: true
       - uses: DataDog/action-prebuildify/node/12@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/14@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/16@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/18@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/19@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,7 +171,7 @@ jobs:
   # Tests
 
   alpine-test:
-    if: ${{ !input.napi-rs }}
+    if: ${{ !inputs.napi-rs }}
     strategy:
       matrix:
         node: [12, 14, 16, 18, 19]
@@ -188,7 +188,7 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   linux-test:
-    if: ${{ !input.napi-rs }}
+    if: ${{ !inputs.napi-rs }}
     needs: linux-x64
     runs-on: ubuntu-latest
     name: linux-test
@@ -208,7 +208,7 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   macos-x64-test:
-    if: ${{ !input.napi-rs }}
+    if: ${{ !inputs.napi-rs }}
     needs: macos
     runs-on: macos-11
     name: macos-x64-test
@@ -228,7 +228,7 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   windows-test:
-    if: ${{ !input.napi-rs }}
+    if: ${{ !inputs.napi-rs }}
     needs: windows
     runs-on: windows-2019
     name: windows-test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,7 +171,7 @@ jobs:
   # Tests
 
   alpine-test:
-    if: inputs.napi-rs == false
+    if: ${{ inputs.napi-rs == 'false' }}
     strategy:
       matrix:
         node: [12, 14, 16, 18, 19]
@@ -188,7 +188,7 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   linux-test:
-    if: inputs.napi-rs == false
+    if: ${{ inputs.napi-rs == 'false' }}
     needs: linux-x64
     runs-on: ubuntu-latest
     name: linux-test
@@ -208,7 +208,7 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   macos-x64-test:
-    if: inputs.napi-rs == false
+    if: ${{ inputs.napi-rs == 'false' }}
     needs: macos
     runs-on: macos-11
     name: macos-x64-test
@@ -228,7 +228,7 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   windows-test:
-    if: inputs.napi-rs == false
+    if: ${{ inputs.napi-rs == 'false' }}
     needs: windows
     runs-on: windows-2019
     name: windows-test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,8 +181,6 @@ jobs:
     name: alpine-test-${{ matrix.node }}
     steps:
       - run: apk update && apk add bash build-base git python3 curl
-      - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && source ~/.cargo/env
-        if: ${{ env.NAPI_RS == 'true' }}
       - uses: actions/checkout@v3
         with:
           submodules: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   linux-x64:
     if: ${{ !contains(inputs.skip, 'linux-x64') }}
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   linux-arm64:
     if: ${{ !contains(inputs.skip, 'linux-arm64') }}
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   linux-arm:
     if: ${{ !contains(inputs.skip, 'linux-arm') }}
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   linuxmusl-x64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
@@ -134,7 +134,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
 
@@ -151,7 +151,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   windows:
     strategy:
@@ -166,7 +166,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   # Tests
 
@@ -180,11 +180,13 @@ jobs:
       image: node:${{ matrix.node }}-alpine
     name: alpine-test-${{ matrix.node }}
     steps:
-      - run: apk update && apk add bash build-base git python3
+      - run: apk update && apk add bash build-base git python3 curl
+      - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && source ~/.cargo/env
+        if: ${{ env.NAPI_RS == 'true' }}
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
 
   linux-test:
     needs: linux-x64
@@ -195,15 +197,15 @@ jobs:
         with:
           submodules: true
       - uses: DataDog/action-prebuildify/node/12@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/14@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/16@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/18@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/19@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
 
   macos-x64-test:
     needs: macos
@@ -214,15 +216,15 @@ jobs:
         with:
           submodules: true
       - uses: DataDog/action-prebuildify/node/12@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/14@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/16@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/18@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/19@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
 
   windows-test:
     needs: windows
@@ -233,12 +235,12 @@ jobs:
         with:
           submodules: true
       - uses: DataDog/action-prebuildify/node/12@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/14@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/16@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/18@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test
       - uses: DataDog/action-prebuildify/node/19@main
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@david.lee/serverless-action-test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-x64:
     if: ${{ !contains(inputs.skip, 'linux-x64') }}
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-arm64:
     if: ${{ !contains(inputs.skip, 'linux-arm64') }}
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-arm:
     if: ${{ !contains(inputs.skip, 'linux-arm') }}
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxmusl-x64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
@@ -134,7 +134,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
 
@@ -151,7 +151,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   windows:
     strategy:
@@ -166,7 +166,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # Tests
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,7 +171,7 @@ jobs:
   # Tests
 
   alpine-test:
-    if: ${{ inputs.napi-rs == 'false' }}
+    if: ${{ !inputs.napi-rs }}
     strategy:
       matrix:
         node: [12, 14, 16, 18, 19]
@@ -188,7 +188,7 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   linux-test:
-    if: ${{ inputs.napi-rs == 'false' }}
+    if: ${{ !inputs.napi-rs }}
     needs: linux-x64
     runs-on: ubuntu-latest
     name: linux-test
@@ -208,7 +208,7 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   macos-x64-test:
-    if: ${{ inputs.napi-rs == 'false' }}
+    if: ${{ !inputs.napi-rs }}
     needs: macos
     runs-on: macos-11
     name: macos-x64-test
@@ -228,7 +228,7 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   windows-test:
-    if: ${{ inputs.napi-rs == 'false' }}
+    if: ${{ !inputs.napi-rs }}
     needs: windows
     runs-on: windows-2019
     name: windows-test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   linux-x64:
     if: ${{ !contains(inputs.skip, 'linux-x64') }}
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   linux-arm64:
     if: ${{ !contains(inputs.skip, 'linux-arm64') }}
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   linux-arm:
     if: ${{ !contains(inputs.skip, 'linux-arm') }}
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   linuxmusl-x64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
@@ -134,7 +134,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
 
@@ -151,7 +151,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   windows:
     strategy:
@@ -166,7 +166,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@david.lee/serverless-action-test
 
   # Tests
 

--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ jobs:
       postbuild: '' # command to run after prebuilds have been generated
       prebuild: '' # command to run before prebuilds are generated
       skip: '' # list of jobs to skip, for example when a platform is not supported
-      target-name: 'addon' # target name in binding.gyp
+      target-name: 'addon' # target name in binding.gyp (or napi.name in package.json for napi-rs projects)
 ```

--- a/prebuild/action.yml
+++ b/prebuild/action.yml
@@ -4,9 +4,7 @@ runs:
     - uses: actions/download-artifact@v3
     - run: $PACKAGE_MANAGER install --ignore-scripts
       shell: bash
-    - run: $PACKAGE_MANAGER install @napi-rs/cli@2.0.0
-      if: ${{ env.NAPI_RS == 'true' }}
-      shell: bash
+      working-directory: ${{ env.DIRECTORY_PATH }}
     - run: yarn exec node $GITHUB_ACTION_PATH
       if: ${{ env.DOCKER_BUILDER == '' }}
       shell: bash

--- a/prebuild/action.yml
+++ b/prebuild/action.yml
@@ -4,6 +4,9 @@ runs:
     - uses: actions/download-artifact@v3
     - run: $PACKAGE_MANAGER install --ignore-scripts
       shell: bash
+    - run: $PACKAGE_MANAGER install @napi-rs/cli@2.0.0
+      if: ${{ env.NAPI_RS == 'true' }}
+      shell: bash
     - run: yarn exec node $GITHUB_ACTION_PATH
       if: ${{ env.DOCKER_BUILDER == '' }}
       shell: bash
@@ -15,6 +18,8 @@ runs:
           -e POSTBUILD="$POSTBUILD" \
           -e PREBUILD="$PREBUILD" \
           -e TARGET_NAME="$TARGET_NAME" \
+          -e NAPI_RS="$NAPI_RS" \
+          -e DIRECTORY_PATH="$DIRECTORY_PATH" \
           -w /usr/action \
           $DOCKER_BUILDER \
           /bin/bash -c 'yarn && cd /usr/workspace && yarn exec node /usr/action'

--- a/prebuild/action.yml
+++ b/prebuild/action.yml
@@ -5,6 +5,9 @@ runs:
     - run: $PACKAGE_MANAGER install --ignore-scripts
       shell: bash
       working-directory: ${{ env.DIRECTORY_PATH }}
+    - run: $PACKAGE_MANAGER install @napi-rs/cli@2.0.0
+      if: ${{ env.NAPI_RS == 'true' }}
+      shell: bash
     - run: yarn exec node $GITHUB_ACTION_PATH
       if: ${{ env.DOCKER_BUILDER == '' }}
       shell: bash

--- a/prebuild/action.yml
+++ b/prebuild/action.yml
@@ -5,9 +5,6 @@ runs:
     - run: $PACKAGE_MANAGER install --ignore-scripts
       shell: bash
       working-directory: ${{ env.DIRECTORY_PATH }}
-    - run: $PACKAGE_MANAGER install @napi-rs/cli@2.0.0
-      if: ${{ env.NAPI_RS == 'true' }}
-      shell: bash
     - run: yarn exec node $GITHUB_ACTION_PATH
       if: ${{ env.DOCKER_BUILDER == '' }}
       shell: bash

--- a/prebuild/index.js
+++ b/prebuild/index.js
@@ -15,13 +15,16 @@ const shell = process.env.SHELL
 
 const {
   NAPI = 'false',
+  NAPI_RS = 'false',
   NODE_VERSIONS = '>=12',
   POSTBUILD = '',
   PREBUILD = '',
-  TARGET_NAME = 'addon'
+  TARGET_NAME = 'addon',
+  DIRECTORY_PATH = '.',
 } = process.env
 
-// https://nodejs.org/en/download/releases/
+console.log("platofrm: " + platform)
+
 const targets = [
   { version: '12.0.0', abi: '72' },
   { version: '13.0.0', abi: '79' },
@@ -31,7 +34,12 @@ const targets = [
   { version: '17.0.1', abi: '102' },
   { version: '18.0.0', abi: '108' },
   { version: '19.0.0', abi: '111' }
-].filter(target => semver.satisfies(target.version, NODE_VERSIONS))
+]
+
+// https://nodejs.org/en/download/releases/
+if (NAPI_RS === 'false') {
+  targets.filter(target => semver.satisfies(target.version, NODE_VERSIONS))
+}
 
 prebuildify()
 
@@ -45,6 +53,8 @@ function prebuildify () {
 
   if (NAPI === 'true') {
     prebuildTarget(arch, { version: targets[0].version, abi: 'napi' })
+  } else if (NAPI_RS === 'true') {
+    prebuildTarget(arch, {})
   } else {
     targets.forEach(target => prebuildTarget(arch, target))
   }
@@ -55,25 +65,68 @@ function prebuildify () {
 }
 
 function prebuildTarget (arch, target) {
+  console.log('arch: ' + arch)
+  console.log('target: ' + target)
+  if (NAPI_RS === 'true' && (platform !== 'linux' && platform !== 'darwin')) return
+  if (NAPI_RS === 'true' && (arch !== 'arm64' && arch !== 'x64')) return
+  if (NAPI_RS === 'true' && platform === 'linux' && libc === 'musl') return
   if (platform === 'linux' && arch === 'ia32' && semver.gte(target.version, '14.0.0')) return
   if (platform === 'win32' && arch === 'ia32' && semver.gte(target.version, '18.0.0')) return
 
-  const output = `prebuilds/${platform}${libc}-${arch}/node-${target.abi}.node`
-  const cmd = [
-    'node-gyp rebuild',
-    `--target=${target.version}`,
-    `--target_arch=${arch}`,
-    `--arch=${arch}`,
-    `--devdir=${cache}`,
-    '--release',
-    '--jobs=max',
-    '--build_v8_with_gn=false',
-    '--v8_enable_pointer_compression=""',
-    '--v8_enable_31bit_smis_on_64bit_arch=""',
-    '--enable_lto=false'
-  ].join(' ')
+  let cmd;
+
+  // only support building for linux and darwin, arm64 and x64
+  if (NAPI_RS === 'true') {
+    let build_target;
+    if (platform === 'linux') {
+      execSync("curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y", { stdio, shell })
+      process.env["PATH"] += path.delimiter + process.env["HOME"] + path.sep + ".cargo" + path.sep + "bin"
+
+      if (arch === 'arm64') {
+        build_target = 'aarch64-unknown-linux-gnu'
+      } else { // arch === 'x64'
+        build_target = 'x86_64-unknown-linux-gnu'
+      }
+    } else { // platform === 'darwin'
+      if (arch === 'arm64') {
+        build_target = 'aarch64-apple-darwin'
+      } else { // arch === 'x64'
+        build_target = 'x86_64-apple-darwin'
+      }
+    }
+    cmd = [
+      `rustup target add ${build_target} &&`,
+      `cd ${DIRECTORY_PATH} &&`,
+      'napi build --release',
+      `--target=${build_target}`,
+    ].join(' ')
+  } else {
+    cmd = [
+      'node-gyp rebuild',
+      `--target=${target.version}`,
+      `--target_arch=${arch}`,
+      `--arch=${arch}`,
+      `--devdir=${cache}`,
+      '--release',
+      '--jobs=max',
+      '--build_v8_with_gn=false',
+      '--v8_enable_pointer_compression=""',
+      '--v8_enable_31bit_smis_on_64bit_arch=""',
+      '--enable_lto=false'
+    ].join(' ')
+  }
+
+  console.log("process env before running cmd")
+  console.log(process.env)
 
   execSync(cmd, { stdio, shell })
 
-  fs.copyFileSync(`build/Release/${TARGET_NAME}.node`, output)
+  if (NAPI_RS === 'true') {
+    console.log("looking for: " + `${DIRECTORY_PATH}/${TARGET_NAME}.node`);
+    const output = `prebuilds/${platform}${libc}-${arch}/${TARGET_NAME}.node`
+    fs.copyFileSync(`${DIRECTORY_PATH}/${TARGET_NAME}.node`, output)
+  } else {
+    const output = `prebuilds/${platform}${libc}-${arch}/node-${target.abi}.node`
+    fs.copyFileSync(`build/Release/${TARGET_NAME}.node`, output)
+  }
 }

--- a/prebuild/index.js
+++ b/prebuild/index.js
@@ -33,11 +33,7 @@ const targets = [
   { version: '17.0.1', abi: '102' },
   { version: '18.0.0', abi: '108' },
   { version: '19.0.0', abi: '111' }
-]
-
-if (NAPI_RS === 'false') {
-  targets.filter(target => semver.satisfies(target.version, NODE_VERSIONS))
-}
+].filter(target => semver.satisfies(target.version, NODE_VERSIONS))
 
 prebuildify()
 

--- a/prebuild/index.js
+++ b/prebuild/index.js
@@ -43,7 +43,7 @@ const napiTargets = {
   'darwin-arm64': 'aarch64-apple-darwin',
   'darwin-x64': 'x86_64-apple-darwin',
   'win32-ia32': 'i686-pc-windows-msvc',
-  'win64-x64': 'x86_64-pc-windows-msvc'
+  'win32-x64': 'x86_64-pc-windows-msvc'
 }
 
 prebuildify()
@@ -112,11 +112,11 @@ function prebuildTarget (arch, target) {
 
   execSync(cmd, { stdio, shell })
 
-  const output = `prebuilds/${platform}${libc}-${arch}/node-${target.abi}.node`
-
   if (NAPI_RS === 'true') {
+    const output = `prebuilds/${platform}${libc}-${arch}/${TARGET_NAME}.node`
     fs.copyFileSync(`${DIRECTORY_PATH}/${TARGET_NAME}.node`, output)
   } else {
+    const output = `prebuilds/${platform}${libc}-${arch}/node-${target.abi}.node`
     fs.copyFileSync(`${DIRECTORY_PATH}/build/Release/${TARGET_NAME}.node`, output)
   }
 }

--- a/prebuild/index.js
+++ b/prebuild/index.js
@@ -86,11 +86,19 @@ function prebuildTarget (arch, target) {
     execSync("curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y", { stdio, shell })
     process.env.PATH += path.delimiter + process.env.HOME + path.sep + '.cargo' + path.sep + 'bin'
 
+    let napiBuildCommand;
+
+    if (platform === 'win32') {
+      napiBuildCommand = `npx ${__dirname + path.sep}node_modules${path.sep}@napi-rs${path.sep}cli build`
+    } else {
+      napiBuildCommand = `${__dirname + path.sep}node_modules${path.sep}.bin${path.sep}napi build`
+    }
+
     cmd = [
       `rustup target add ${buildTarget} &&`,
       `cd ${DIRECTORY_PATH} &&`,
       `${rustEnvFlags}`,
-      'napi build',
+      napiBuildCommand,
       '--release',
       `--target=${buildTarget}`
     ].join(' ')

--- a/prebuild/index.js
+++ b/prebuild/index.js
@@ -90,7 +90,8 @@ function prebuildTarget (arch, target) {
     cmd = [
       `rustup target add ${build_target} &&`,
       `cd ${DIRECTORY_PATH} &&`,
-      'napi build --release',
+      'napi build',
+      '--release',
       `--target=${build_target}`,
     ].join(' ')
   } else {

--- a/prebuild/index.js
+++ b/prebuild/index.js
@@ -59,7 +59,6 @@ function prebuildify () {
 }
 
 function prebuildTarget (arch, target) {
-  // napi-rs doesn't support linux ia32. See here for supported platforms: https://napi.rs/docs/cross-build/summary
   if (NAPI_RS === 'true' && platform === 'linux' && arch === 'ia32') return
 
   if (platform === 'linux' && arch === 'ia32' && semver.gte(target.version, '14.0.0')) return
@@ -86,6 +85,9 @@ function prebuildTarget (arch, target) {
               break
             case 'x64':
               build_target = 'x86_64-unknown-linux-gnu'
+              break
+            case 'ia32':
+              build_target = 'i686-unknown-linux-gnu'
               break
           }
         }

--- a/prebuild/index.js
+++ b/prebuild/index.js
@@ -109,14 +109,12 @@ function prebuildTarget (arch, target) {
     }
     execSync("curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y", { stdio, shell })
     process.env["PATH"] += path.delimiter + process.env["HOME"] + path.sep + ".cargo" + path.sep + "bin"
-
-    const napi_rs_path = `${process.cwd()}/node_modules/@napi-rs/cli/scripts/index.js`;
     
     cmd = [
       `rustup target add ${build_target} &&`,
       `cd ${DIRECTORY_PATH} &&`,
       `${rust_env_flags}`,
-      `${napi_rs_path} build`,
+      `napi build`,
       '--release',
       `--target=${build_target}`
     ].join(' ')

--- a/prebuild/index.js
+++ b/prebuild/index.js
@@ -19,12 +19,11 @@ const {
   NODE_VERSIONS = '>=12',
   POSTBUILD = '',
   PREBUILD = '',
-  TARGET_NAME = 'addon',
   DIRECTORY_PATH = '.',
+  TARGET_NAME = 'addon'
 } = process.env
 
-console.log("platofrm: " + platform)
-
+// https://nodejs.org/en/download/releases/
 const targets = [
   { version: '12.0.0', abi: '72' },
   { version: '13.0.0', abi: '79' },
@@ -36,7 +35,6 @@ const targets = [
   { version: '19.0.0', abi: '111' }
 ]
 
-// https://nodejs.org/en/download/releases/
 if (NAPI_RS === 'false') {
   targets.filter(target => semver.satisfies(target.version, NODE_VERSIONS))
 }
@@ -65,17 +63,16 @@ function prebuildify () {
 }
 
 function prebuildTarget (arch, target) {
-  console.log('arch: ' + arch)
-  console.log('target: ' + target)
+  // only support building for linux and darwin, arm64 and x64
   if (NAPI_RS === 'true' && (platform !== 'linux' && platform !== 'darwin')) return
   if (NAPI_RS === 'true' && (arch !== 'arm64' && arch !== 'x64')) return
   if (NAPI_RS === 'true' && platform === 'linux' && libc === 'musl') return
+
   if (platform === 'linux' && arch === 'ia32' && semver.gte(target.version, '14.0.0')) return
   if (platform === 'win32' && arch === 'ia32' && semver.gte(target.version, '18.0.0')) return
 
   let cmd;
 
-  // only support building for linux and darwin, arm64 and x64
   if (NAPI_RS === 'true') {
     let build_target;
     if (platform === 'linux') {
@@ -116,13 +113,9 @@ function prebuildTarget (arch, target) {
     ].join(' ')
   }
 
-  console.log("process env before running cmd")
-  console.log(process.env)
-
   execSync(cmd, { stdio, shell })
 
   if (NAPI_RS === 'true') {
-    console.log("looking for: " + `${DIRECTORY_PATH}/${TARGET_NAME}.node`);
     const output = `prebuilds/${platform}${libc}-${arch}/${TARGET_NAME}.node`
     fs.copyFileSync(`${DIRECTORY_PATH}/${TARGET_NAME}.node`, output)
   } else {

--- a/prebuild/index.js
+++ b/prebuild/index.js
@@ -70,8 +70,6 @@ function prebuildTarget (arch, target) {
   if (NAPI_RS === 'true') {
     let build_target;
     let rust_env_flags = "";
-    console.log("platform: " + platform);
-    console.log("arch: " + arch);
     switch (platform) {
       case 'linux':
         if (libc === 'musl') {
@@ -111,12 +109,14 @@ function prebuildTarget (arch, target) {
     }
     execSync("curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y", { stdio, shell })
     process.env["PATH"] += path.delimiter + process.env["HOME"] + path.sep + ".cargo" + path.sep + "bin"
-    console.log("build_target: " + build_target);
+
+    const napi_rs_path = `${process.cwd()}/node_modules/@napi-rs/cli/scripts/index.js`;
+    
     cmd = [
       `rustup target add ${build_target} &&`,
       `cd ${DIRECTORY_PATH} &&`,
       `${rust_env_flags}`,
-      'napi build',
+      `${napi_rs_path} build`,
       '--release',
       `--target=${build_target}`
     ].join(' ')

--- a/prebuild/node_modules/.bin/napi
+++ b/prebuild/node_modules/.bin/napi
@@ -1,0 +1,1 @@
+../@napi-rs/cli/scripts/index.js

--- a/prebuild/node_modules/@napi-rs/cli/LICENSE
+++ b/prebuild/node_modules/@napi-rs/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 LongYinan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/prebuild/node_modules/@napi-rs/cli/README.md
+++ b/prebuild/node_modules/@napi-rs/cli/README.md
@@ -1,0 +1,94 @@
+# `@napi-rs/cli`
+
+[![Download](https://img.shields.io/npm/dm/@napi-rs/cli)](https://www.npmjs.com/package/@napi-rs/cli)
+[![Install size](https://packagephobia.com/badge?p=@napi-rs/cli)](https://packagephobia.com/result?p=@napi-rs/cli)
+<a href="https://discord.gg/SpWzYHsKHs">
+<img src="https://img.shields.io/discord/874290842444111882.svg?logo=discord&style=flat-square"
+    alt="chat" />
+</a>
+
+> Cli tools for napi-rs
+
+## Commands
+
+### Debug mode
+
+```bash
+DEBUG="napi:*" napi [command]
+```
+
+### `napi build`
+
+> Build command. Build rust codes and copy the dynamic lib binary file to the dist dir.
+
+#### `--platform`
+
+> default `false`
+
+Append `platform-arch-[abi]` name to dist file. eg: `index.darwin-x64.node`.
+
+#### `--release`
+
+> default `false`
+
+Is release build. This flag will be passed to `Cargo` directly.
+
+#### `--features`
+
+> default `''`
+
+Cargo features, passthrough to `cargo build` command.
+
+#### `--config,-c`
+
+> default `package.json`
+
+`napi-rs` config file name. `napi-rs` config example :
+
+```js
+{
+  "name": "@native-binding/fib",
+  "version": "0.1.0",
+  "napi": {
+    "name": "fib", // binary name
+    "triples": {
+      "defaults": true, // default true, if this value is true, will build `x86_64-pc-windows-msvc`, `x86_64-apple-darwin` and `x86_64-unknown-linux-gnu`
+      "addition": [
+        "x86_64-unknown-linux-musl",
+        "x86_64-unknown-freebsd",
+        "aarch64-unknown-linux-gnu"
+      ]
+    }
+  }
+}
+```
+
+#### `--cargo-name`
+
+> default `undefined`
+
+If not set, cli will read the `package.name` field in `Cargo.toml` under `process.cwd()`. The `-` in the name will be replaced with `_`.
+
+#### `--target`
+
+> default `undefined`
+
+You can also define this value using the `RUST_TARGET` environment variable.
+
+This value will be passed to `Cargo build` command directly. eg: `napi build --target x86_64-unknown-linux-musl`
+
+#### `--cargo-flags`
+
+> default `undefined`
+
+Other flags you want pass to `Cargo build`.
+
+#### `--cargo-cwd`
+
+> default `undefined`
+
+This flag can be used to build binaries that are not in the current directory. The path that is passed to this flag should be relative to the current directory.
+
+### `napi artifacts`
+
+> Copy artifact files in Github actions.

--- a/prebuild/node_modules/@napi-rs/cli/package.json
+++ b/prebuild/node_modules/@napi-rs/cli/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@napi-rs/cli",
+  "version": "2.0.0",
+  "description": "Cli tools for napi-rs",
+  "keywords": [
+    "cli",
+    "rust",
+    "napi",
+    "n-api",
+    "neon"
+  ],
+  "author": "LongYinan <lynweklm@gmail.com>",
+  "homepage": "https://github.com/napi-rs/napi-rs",
+  "license": "MIT",
+  "bin": {
+    "napi": "./scripts/index.js"
+  },
+  "files": [
+    "scripts"
+  ],
+  "engines": {
+    "node": ">= 10"
+  },
+  "maintainers": [
+    {
+      "name": "LongYinan",
+      "email": "lynweklm@gmail.com",
+      "homepage": "https://github.com/Brooooooklyn"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/napi-rs/napi-rs.git"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "bugs": {
+    "url": "https://github.com/napi-rs/napi-rs/issues"
+  },
+  "devDependencies": {
+    "@octokit/rest": "^18.12.0",
+    "@types/inquirer": "^8.1.3",
+    "@types/js-yaml": "^4.0.5",
+    "@types/lodash-es": "^4.17.5",
+    "chalk": "4",
+    "clipanion": "^3.1.0",
+    "debug": "^4.3.3",
+    "fdir": "^5.1.0",
+    "inquirer": "^8.2.0",
+    "js-yaml": "^4.1.0",
+    "lodash-es": "4.17.21",
+    "toml": "^3.0.0",
+    "tslib": "^2.3.1",
+    "typanion": "^3.7.1"
+  },
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/Brooooooklyn"
+  }
+}

--- a/prebuild/package.json
+++ b/prebuild/package.json
@@ -2,8 +2,5 @@
   "private": true,
   "dependencies": {
     "semver": "^7.3.5"
-  },
-  "devDependencies": {
-    "@napi-rs/cli": "2.0.0"
   }
 }

--- a/prebuild/package.json
+++ b/prebuild/package.json
@@ -2,5 +2,8 @@
   "private": true,
   "dependencies": {
     "semver": "^7.3.5"
+  },
+  "devDependencies": {
+    "@napi-rs/cli": "2.0.0"
   }
 }

--- a/prebuild/yarn.lock
+++ b/prebuild/yarn.lock
@@ -2,7 +2,6 @@
 # yarn lockfile v1
 
 
-
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"

--- a/prebuild/yarn.lock
+++ b/prebuild/yarn.lock
@@ -2,10 +2,6 @@
 # yarn lockfile v1
 
 
-"@napi-rs/cli@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@napi-rs/cli/-/cli-2.0.0.tgz#cf237de31548f68ad7d173279293bf24a70e5f83"
-  integrity sha512-2R24dtZoPYb9TxIQJbhUSloSVK4HGfa6CVn5JgUeO9WTvZecC5i8WaFm2CC7GWbYmDlPu2AnULwaSr+AP7r1RQ==
 
 lru-cache@^6.0.0:
   version "6.0.0"

--- a/prebuild/yarn.lock
+++ b/prebuild/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@napi-rs/cli@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@napi-rs/cli/-/cli-2.0.0.tgz#cf237de31548f68ad7d173279293bf24a70e5f83"
+  integrity sha512-2R24dtZoPYb9TxIQJbhUSloSVK4HGfa6CVn5JgUeO9WTvZecC5i8WaFm2CC7GWbYmDlPu2AnULwaSr+AP7r1RQ==
+
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"

--- a/test/action.yml
+++ b/test/action.yml
@@ -4,5 +4,7 @@ runs:
     - uses: actions/download-artifact@v3
     - run: $PACKAGE_MANAGER install --ignore-scripts
       shell: bash
+      working-directory: ${{ env.DIRECTORY_PATH }}
     - run: $PACKAGE_MANAGER test
       shell: bash
+      working-directory: ${{ env.DIRECTORY_PATH }}

--- a/test/action.yml
+++ b/test/action.yml
@@ -5,6 +5,9 @@ runs:
     - run: $PACKAGE_MANAGER install --ignore-scripts
       shell: bash
       working-directory: ${{ env.DIRECTORY_PATH }}
+    - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      if: ${{ env.NAPI_RS == 'true' }}
+      shell: bash
     - run: $PACKAGE_MANAGER test
       shell: bash
       working-directory: ${{ env.DIRECTORY_PATH }}


### PR DESCRIPTION
Adds support for building napi-rs projects.

This includes two new workflow inputs:
- `napi-rs` (default false)
   - whether or not to build for a napi-rs project
- `directory-path` (default ".")
   - the path to the directory containing the project, relative to the repo root. 

Supports building napi-rs projects for all targets but linux-32 ([see comment](https://github.com/DataDog/action-prebuildify/pull/22#discussion_r1100780228)).

Tested by setting each of the spawned jobs ([such as this](https://github.com/DataDog/action-prebuildify/blob/d1dca92a4b8d5b38bbc4cde07b1c7aae88093bab/.github/workflows/build.yml#L79)) to use my branch (`david.lee/serverless-action-test`) instead of `main` and making sure all CI tests pass. Tested the build works correctly by setting up this workflow (specifying to use my branch) in an example app repo, that holds a napi-rs project.