### PR TITLE
Workaround for https://github.com/nodejs/node-gyp/issues/2750

### DIFF
--- a/prebuild/index.js
+++ b/prebuild/index.js
@@ -114,7 +114,10 @@ function prebuildTarget (arch, target) {
       '--build_v8_with_gn=false',
       '--v8_enable_pointer_compression=""',
       '--v8_enable_31bit_smis_on_64bit_arch=""',
-      '--enable_lto=false'
+      '--enable_lto=false',
+      // Workaround for https://github.com/nodejs/node-gyp/issues/2750
+      // taken from https://github.com/nodejs/node-gyp/issues/2673#issuecomment-1196931379
+      '--openssl_fips=""'
     ].join(' ')
   }
 


### PR DESCRIPTION
Without this workaround node18 fails to generate prebuilds for node versions < 18 with: gyp: name 'openssl_fips' is not defined while evaluating condition 'openssl_fips != ""' in binding.gyp while trying to load binding.gyp