### PR TITLE
Cache node headers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,11 +97,10 @@ jobs:
   linux-x64:
     if: ${{ !contains(inputs.skip, 'linux-x64') }}
     runs-on: ubuntu-latest
-    container:
-      image: rochdev/holy-node-box:12-amd64
     name: linux-x64
     env:
       ARCH: x64
+      DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@v3
         with:
@@ -146,7 +145,7 @@ jobs:
       ARCH: x64
       LIBC: musl
     steps:
-      - run: apk update && apk add bash build-base git python curl
+      - run: apk update && apk add bash build-base git python curl tar zstd
       - uses: actions/checkout@v3
         with:
           submodules: true

--- a/prebuild/action.yml
+++ b/prebuild/action.yml
@@ -5,6 +5,30 @@ runs:
     - run: $PACKAGE_MANAGER install --ignore-scripts
       shell: bash
       working-directory: ${{ env.DIRECTORY_PATH }}
+    - run: |
+        cd $GITHUB_ACTION_PATH
+        yarn exec -s -- node fetch_node_headers.js >> "$GITHUB_OUTPUT"
+        echo "NODE_HEADERS_DIRECTORY=/tmp/node_headers" >> "$GITHUB_ENV"
+      id: compute-node-targets-hash
+      shell: bash
+    - name: Restore node headers
+      if: ${{ env.CACHE == 'true' }}
+      id: cache-node-headers
+      uses: actions/cache/restore@v3
+      with:
+        path: ${{ env.NODE_HEADERS_DIRECTORY }}
+        key: node-headers-cache-${{ runner.os }}-version${{ env.NODE_VERSIONS }}-${{ steps.compute-node-targets-hash.outputs.hash }}
+    - if: ${{ steps.cache-node-headers.outputs.cache-hit != 'true' }}
+      run: |
+        cd $GITHUB_ACTION_PATH
+        yarn exec -s -- node fetch_node_headers.js $NODE_HEADERS_DIRECTORY
+      shell: bash
+    - name: Save node headers
+      if: ${{ env.CACHE == 'true' && steps.cache-node-headers.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@v3
+      with:
+        path: ${{ env.NODE_HEADERS_DIRECTORY }}
+        key: ${{ steps.cache-node-headers.outputs.cache-primary-key }}
     - run: yarn exec node $GITHUB_ACTION_PATH
       if: ${{ env.DOCKER_BUILDER == '' }}
       shell: bash
@@ -12,6 +36,7 @@ runs:
         docker run \
           -v $GITHUB_ACTION_PATH:/usr/action \
           -v $PWD:/usr/workspace \
+          -v $NODE_HEADERS_DIRECTORY:/usr/node_headers \
           -e NAPI="$NAPI" \
           -e POSTBUILD="$POSTBUILD" \
           -e PREBUILD="$PREBUILD" \
@@ -19,6 +44,7 @@ runs:
           -e NAPI_RS="$NAPI_RS" \
           -e DIRECTORY_PATH="$DIRECTORY_PATH" \
           -e NODE_VERSIONS="$NODE_VERSIONS" \
+          -e NODE_HEADERS_DIRECTORY="/usr/node_headers" \
           -w /usr/action \
           $DOCKER_BUILDER \
           /bin/bash -c 'yarn && cd /usr/workspace && yarn exec node /usr/action'

--- a/prebuild/fetch_node_headers.js
+++ b/prebuild/fetch_node_headers.js
@@ -1,15 +1,14 @@
 "use strict";
 
 const retry = require("retry");
-const semver = require("semver");
-const { nodeTargets } = require("./targets");
+const { getFilteredNodeTargets } = require("./targets");
 const execSync = require("child_process").execSync;
 
 const stdio = [0, 1, 2];
 const shell = process.env.SHELL;
 
 const { NODE_VERSIONS = ">=12" } = process.env;
-const targets = nodeTargets.filter(target => semver.satisfies(target.version, NODE_VERSIONS))
+const targets = getFilteredNodeTargets(NODE_VERSIONS);
 
 function fetchNodeHeaders(version, devDir) {
   let operation = retry.operation({
@@ -45,7 +44,7 @@ function computeNodeTargetsHash() {
   const crypto = require("crypto");
   const hash = crypto
     .createHash("sha256")
-    .update(JSON.stringify(nodeTargets))
+    .update(JSON.stringify(targets))
     .digest("hex");
   console.log(`hash=${hash}`);
 }

--- a/prebuild/fetch_node_headers.js
+++ b/prebuild/fetch_node_headers.js
@@ -1,0 +1,63 @@
+"use strict";
+
+const retry = require("retry");
+const semver = require("semver");
+const { nodeTargets } = require("./targets");
+const execSync = require("child_process").execSync;
+
+const stdio = [0, 1, 2];
+const shell = process.env.SHELL;
+
+const { NODE_VERSIONS = ">=12" } = process.env;
+const targets = nodeTargets.filter(target => semver.satisfies(target.version, NODE_VERSIONS))
+
+function fetchNodeHeaders(version, devDir) {
+  let operation = retry.operation({
+    retries: 3,
+    factor: 2,
+    minTimeout: 1 * 1000,
+    maxTimeout: 60 * 1000,
+    randomize: true,
+  });
+  return new Promise((resolve, reject) => {
+    operation.attempt(() => {
+      const cmd = [
+        "node-gyp install",
+        `--target=${version}`,
+        `--devdir=${devDir}`,
+      ].join(" ");
+      try {
+        execSync(cmd, { stdio, shell });
+      } catch (err) {
+        if (operation.retry(err)) {
+          return;
+        } else if (err) {
+          reject(err);
+          return;
+        }
+      }
+      resolve();
+    });
+  });
+}
+
+function computeNodeTargetsHash() {
+  const crypto = require("crypto");
+  const hash = crypto
+    .createHash("sha256")
+    .update(JSON.stringify(nodeTargets))
+    .digest("hex");
+  console.log(`hash=${hash}`);
+}
+
+function fetchAllNodeHeaders(targetDir) {
+  for (const target of targets) {
+    fetchNodeHeaders(target.version, targetDir);
+  }
+}
+
+if (process.argv.length == 2) {
+  computeNodeTargetsHash();
+} else {
+  fetchAllNodeHeaders(process.argv[2]);
+}

--- a/prebuild/index.js
+++ b/prebuild/index.js
@@ -5,7 +5,7 @@ const os = require('os')
 const fs = require('fs')
 const execSync = require('child_process').execSync
 const semver = require('semver')
-const { nodeTargets } = require('./targets')
+const { getFilteredNodeTargets } = require('./targets')
 
 const platform = os.platform()
 const arch = process.env.ARCH || os.arch()
@@ -25,7 +25,7 @@ const {
 } = process.env
 
 // https://nodejs.org/en/download/releases/
-const targets = nodeTargets.filter(target => semver.satisfies(target.version, NODE_VERSIONS))
+const targets = getFilteredNodeTargets(NODE_VERSIONS)
 
 const napiTargets = {
   'linux-musl': 'x86_64-unknown-linux-musl',

--- a/prebuild/index.js
+++ b/prebuild/index.js
@@ -5,11 +5,11 @@ const os = require('os')
 const fs = require('fs')
 const execSync = require('child_process').execSync
 const semver = require('semver')
+const { nodeTargets } = require('./targets')
 
 const platform = os.platform()
 const arch = process.env.ARCH || os.arch()
 const libc = process.env.LIBC || ''
-const cache = path.join(os.tmpdir(), 'prebuilds')
 const stdio = [0, 1, 2]
 const shell = process.env.SHELL
 
@@ -20,21 +20,12 @@ const {
   POSTBUILD = '',
   PREBUILD = '',
   DIRECTORY_PATH = '.',
-  TARGET_NAME = 'addon'
+  TARGET_NAME = 'addon',
+  NODE_HEADERS_DIRECTORY = path.join(os.tmpdir(), 'prebuilds'),
 } = process.env
 
 // https://nodejs.org/en/download/releases/
-const targets = [
-  { version: '12.0.0', abi: '72' },
-  { version: '13.0.0', abi: '79' },
-  { version: '14.0.0', abi: '83' },
-  { version: '15.0.0', abi: '88' },
-  { version: '16.0.0', abi: '93' },
-  { version: '17.0.1', abi: '102' },
-  { version: '18.0.0', abi: '108' },
-  { version: '19.0.0', abi: '111' },
-  { version: '20.0.0', abi: '115' }
-].filter(target => semver.satisfies(target.version, NODE_VERSIONS))
+const targets = nodeTargets.filter(target => semver.satisfies(target.version, NODE_VERSIONS))
 
 const napiTargets = {
   'linux-musl': 'x86_64-unknown-linux-musl',
@@ -50,7 +41,7 @@ const napiTargets = {
 prebuildify()
 
 function prebuildify () {
-  fs.mkdirSync(cache, { recursive: true })
+  fs.mkdirSync(NODE_HEADERS_DIRECTORY, { recursive: true })
   fs.mkdirSync(`prebuilds/${platform}${libc}-${arch}`, { recursive: true })
 
   if (PREBUILD) {
@@ -107,9 +98,8 @@ function prebuildTarget (arch, target) {
     cmd = [
       'node-gyp rebuild',
       `--target=${target.version}`,
-      `--target_arch=${arch}`,
       `--arch=${arch}`,
-      `--devdir=${cache}`,
+      `--devdir=${NODE_HEADERS_DIRECTORY}`,
       '--release',
       '--jobs=max',
       '--build_v8_with_gn=false',

--- a/prebuild/node_modules/retry/License
+++ b/prebuild/node_modules/retry/License
@@ -1,0 +1,21 @@
+Copyright (c) 2011:
+Tim Koschützki (tim@debuggable.com)
+Felix Geisendörfer (felix@debuggable.com)
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.

--- a/prebuild/node_modules/retry/README.md
+++ b/prebuild/node_modules/retry/README.md
@@ -1,0 +1,227 @@
+<!-- badges/ -->
+[![Build Status](https://secure.travis-ci.org/tim-kos/node-retry.svg?branch=master)](http://travis-ci.org/tim-kos/node-retry "Check this project's build status on TravisCI")
+[![codecov](https://codecov.io/gh/tim-kos/node-retry/branch/master/graph/badge.svg)](https://codecov.io/gh/tim-kos/node-retry)
+<!-- /badges -->
+
+# retry
+
+Abstraction for exponential and custom retry strategies for failed operations.
+
+## Installation
+
+    npm install retry
+
+## Current Status
+
+This module has been tested and is ready to be used.
+
+## Tutorial
+
+The example below will retry a potentially failing `dns.resolve` operation
+`10` times using an exponential backoff strategy. With the default settings, this
+means the last attempt is made after `17 minutes and 3 seconds`.
+
+``` javascript
+var dns = require('dns');
+var retry = require('retry');
+
+function faultTolerantResolve(address, cb) {
+  var operation = retry.operation();
+
+  operation.attempt(function(currentAttempt) {
+    dns.resolve(address, function(err, addresses) {
+      if (operation.retry(err)) {
+        return;
+      }
+
+      cb(err ? operation.mainError() : null, addresses);
+    });
+  });
+}
+
+faultTolerantResolve('nodejs.org', function(err, addresses) {
+  console.log(err, addresses);
+});
+```
+
+Of course you can also configure the factors that go into the exponential
+backoff. See the API documentation below for all available settings.
+currentAttempt is an int representing the number of attempts so far.
+
+``` javascript
+var operation = retry.operation({
+  retries: 5,
+  factor: 3,
+  minTimeout: 1 * 1000,
+  maxTimeout: 60 * 1000,
+  randomize: true,
+});
+```
+
+## API
+
+### retry.operation([options])
+
+Creates a new `RetryOperation` object. `options` is the same as `retry.timeouts()`'s `options`, with three additions:
+
+* `forever`: Whether to retry forever, defaults to `false`.
+* `unref`: Whether to [unref](https://nodejs.org/api/timers.html#timers_unref) the setTimeout's, defaults to `false`.
+* `maxRetryTime`: The maximum time (in milliseconds) that the retried operation is allowed to run. Default is `Infinity`.  
+
+### retry.timeouts([options])
+
+Returns an array of timeouts. All time `options` and return values are in
+milliseconds. If `options` is an array, a copy of that array is returned.
+
+`options` is a JS object that can contain any of the following keys:
+
+* `retries`: The maximum amount of times to retry the operation. Default is `10`. Seting this to `1` means `do it once, then retry it once`.
+* `factor`: The exponential factor to use. Default is `2`.
+* `minTimeout`: The number of milliseconds before starting the first retry. Default is `1000`.
+* `maxTimeout`: The maximum number of milliseconds between two retries. Default is `Infinity`.
+* `randomize`: Randomizes the timeouts by multiplying with a factor between `1` to `2`. Default is `false`.
+
+The formula used to calculate the individual timeouts is:
+
+```
+Math.min(random * minTimeout * Math.pow(factor, attempt), maxTimeout)
+```
+
+Have a look at [this article][article] for a better explanation of approach.
+
+If you want to tune your `factor` / `times` settings to attempt the last retry
+after a certain amount of time, you can use wolfram alpha. For example in order
+to tune for `10` attempts in `5 minutes`, you can use this equation:
+
+![screenshot](https://github.com/tim-kos/node-retry/raw/master/equation.gif)
+
+Explaining the various values from left to right:
+
+* `k = 0 ... 9`:  The `retries` value (10)
+* `1000`: The `minTimeout` value in ms (1000)
+* `x^k`: No need to change this, `x` will be your resulting factor
+* `5 * 60 * 1000`: The desired total amount of time for retrying in ms (5 minutes)
+
+To make this a little easier for you, use wolfram alpha to do the calculations:
+
+<http://www.wolframalpha.com/input/?i=Sum%5B1000*x^k%2C+{k%2C+0%2C+9}%5D+%3D+5+*+60+*+1000>
+
+[article]: http://dthain.blogspot.com/2009/02/exponential-backoff-in-distributed.html
+
+### retry.createTimeout(attempt, opts)
+
+Returns a new `timeout` (integer in milliseconds) based on the given parameters.
+
+`attempt` is an integer representing for which retry the timeout should be calculated. If your retry operation was executed 4 times you had one attempt and 3 retries. If you then want to calculate a new timeout, you should set `attempt` to 4 (attempts are zero-indexed).
+
+`opts` can include `factor`, `minTimeout`, `randomize` (boolean) and `maxTimeout`. They are documented above.
+
+`retry.createTimeout()` is used internally by `retry.timeouts()` and is public for you to be able to create your own timeouts for reinserting an item, see [issue #13](https://github.com/tim-kos/node-retry/issues/13).
+
+### retry.wrap(obj, [options], [methodNames])
+
+Wrap all functions of the `obj` with retry. Optionally you can pass operation options and
+an array of method names which need to be wrapped.
+
+```
+retry.wrap(obj)
+
+retry.wrap(obj, ['method1', 'method2'])
+
+retry.wrap(obj, {retries: 3})
+
+retry.wrap(obj, {retries: 3}, ['method1', 'method2'])
+```
+The `options` object can take any options that the usual call to `retry.operation` can take.
+
+### new RetryOperation(timeouts, [options])
+
+Creates a new `RetryOperation` where `timeouts` is an array where each value is
+a timeout given in milliseconds.
+
+Available options:
+* `forever`: Whether to retry forever, defaults to `false`.
+* `unref`: Wether to [unref](https://nodejs.org/api/timers.html#timers_unref) the setTimeout's, defaults to `false`.
+
+If `forever` is true, the following changes happen:
+* `RetryOperation.errors()` will only output an array of one item: the last error.
+* `RetryOperation` will repeatedly use the `timeouts` array. Once all of its timeouts have been used up, it restarts with the first timeout, then uses the second and so on.
+
+#### retryOperation.errors()
+
+Returns an array of all errors that have been passed to `retryOperation.retry()` so far. The
+returning array has the errors ordered chronologically based on when they were passed to
+`retryOperation.retry()`, which means the first passed error is at index zero and the last is
+at the last index.
+
+#### retryOperation.mainError()
+
+A reference to the error object that occured most frequently. Errors are
+compared using the `error.message` property.
+
+If multiple error messages occured the same amount of time, the last error
+object with that message is returned.
+
+If no errors occured so far, the value is `null`.
+
+#### retryOperation.attempt(fn, timeoutOps)
+
+Defines the function `fn` that is to be retried and executes it for the first
+time right away. The `fn` function can receive an optional `currentAttempt` callback that represents the number of attempts to execute `fn` so far.
+
+Optionally defines `timeoutOps` which is an object having a property `timeout` in miliseconds and a property `cb` callback function.
+Whenever your retry operation takes longer than `timeout` to execute, the timeout callback function `cb` is called.
+
+
+#### retryOperation.try(fn)
+
+This is an alias for `retryOperation.attempt(fn)`. This is deprecated. Please use `retryOperation.attempt(fn)` instead.
+
+#### retryOperation.start(fn)
+
+This is an alias for `retryOperation.attempt(fn)`. This is deprecated. Please use `retryOperation.attempt(fn)` instead.
+
+#### retryOperation.retry(error)
+
+Returns `false` when no `error` value is given, or the maximum amount of retries
+has been reached.
+
+Otherwise it returns `true`, and retries the operation after the timeout for
+the current attempt number.
+
+#### retryOperation.stop()
+
+Allows you to stop the operation being retried. Useful for aborting the operation on a fatal error etc.
+
+#### retryOperation.reset()
+
+Resets the internal state of the operation object, so that you can call `attempt()` again as if this was a new operation object.
+
+#### retryOperation.attempts()
+
+Returns an int representing the number of attempts it took to call `fn` before it was successful.
+
+## License
+
+retry is licensed under the MIT license.
+
+
+# Changelog
+
+0.10.0 Adding `stop` functionality, thanks to @maxnachlinger.
+
+0.9.0 Adding `unref` functionality, thanks to @satazor.
+
+0.8.0 Implementing retry.wrap.
+
+0.7.0 Some bug fixes and made retry.createTimeout() public. Fixed issues [#10](https://github.com/tim-kos/node-retry/issues/10), [#12](https://github.com/tim-kos/node-retry/issues/12), and [#13](https://github.com/tim-kos/node-retry/issues/13).
+
+0.6.0 Introduced optional timeOps parameter for the attempt() function which is an object having a property timeout in milliseconds and a property cb callback function. Whenever your retry operation takes longer than timeout to execute, the timeout callback function cb is called.
+
+0.5.0 Some minor refactoring.
+
+0.4.0 Changed retryOperation.try() to retryOperation.attempt(). Deprecated the aliases start() and try() for it.
+
+0.3.0 Added retryOperation.start() which is an alias for retryOperation.try().
+
+0.2.0 Added attempts() function and parameter to retryOperation.try() representing the number of attempts it took to call fn().

--- a/prebuild/node_modules/retry/example/dns.js
+++ b/prebuild/node_modules/retry/example/dns.js
@@ -1,0 +1,31 @@
+var dns = require('dns');
+var retry = require('../lib/retry');
+
+function faultTolerantResolve(address, cb) {
+  var opts = {
+    retries: 2,
+    factor: 2,
+    minTimeout: 1 * 1000,
+    maxTimeout: 2 * 1000,
+    randomize: true
+  };
+  var operation = retry.operation(opts);
+
+  operation.attempt(function(currentAttempt) {
+    dns.resolve(address, function(err, addresses) {
+      if (operation.retry(err)) {
+        return;
+      }
+
+      cb(operation.mainError(), operation.errors(), addresses);
+    });
+  });
+}
+
+faultTolerantResolve('nodejs.org', function(err, errors, addresses) {
+  console.warn('err:');
+  console.log(err);
+
+  console.warn('addresses:');
+  console.log(addresses);
+});

--- a/prebuild/node_modules/retry/example/stop.js
+++ b/prebuild/node_modules/retry/example/stop.js
@@ -1,0 +1,40 @@
+var retry = require('../lib/retry');
+
+function attemptAsyncOperation(someInput, cb) {
+  var opts = {
+    retries: 2,
+    factor: 2,
+    minTimeout: 1 * 1000,
+    maxTimeout: 2 * 1000,
+    randomize: true
+  };
+  var operation = retry.operation(opts);
+
+  operation.attempt(function(currentAttempt) {
+    failingAsyncOperation(someInput, function(err, result) {
+
+      if (err && err.message === 'A fatal error') {
+        operation.stop();
+        return cb(err);
+      }
+
+      if (operation.retry(err)) {
+        return;
+      }
+
+      cb(operation.mainError(), operation.errors(), result);
+    });
+  });
+}
+
+attemptAsyncOperation('test input', function(err, errors, result) {
+  console.warn('err:');
+  console.log(err);
+
+  console.warn('result:');
+  console.log(result);
+});
+
+function failingAsyncOperation(input, cb) {
+  return setImmediate(cb.bind(null, new Error('A fatal error')));
+}

--- a/prebuild/node_modules/retry/index.js
+++ b/prebuild/node_modules/retry/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/retry');

--- a/prebuild/node_modules/retry/lib/retry.js
+++ b/prebuild/node_modules/retry/lib/retry.js
@@ -1,0 +1,100 @@
+var RetryOperation = require('./retry_operation');
+
+exports.operation = function(options) {
+  var timeouts = exports.timeouts(options);
+  return new RetryOperation(timeouts, {
+      forever: options && (options.forever || options.retries === Infinity),
+      unref: options && options.unref,
+      maxRetryTime: options && options.maxRetryTime
+  });
+};
+
+exports.timeouts = function(options) {
+  if (options instanceof Array) {
+    return [].concat(options);
+  }
+
+  var opts = {
+    retries: 10,
+    factor: 2,
+    minTimeout: 1 * 1000,
+    maxTimeout: Infinity,
+    randomize: false
+  };
+  for (var key in options) {
+    opts[key] = options[key];
+  }
+
+  if (opts.minTimeout > opts.maxTimeout) {
+    throw new Error('minTimeout is greater than maxTimeout');
+  }
+
+  var timeouts = [];
+  for (var i = 0; i < opts.retries; i++) {
+    timeouts.push(this.createTimeout(i, opts));
+  }
+
+  if (options && options.forever && !timeouts.length) {
+    timeouts.push(this.createTimeout(i, opts));
+  }
+
+  // sort the array numerically ascending
+  timeouts.sort(function(a,b) {
+    return a - b;
+  });
+
+  return timeouts;
+};
+
+exports.createTimeout = function(attempt, opts) {
+  var random = (opts.randomize)
+    ? (Math.random() + 1)
+    : 1;
+
+  var timeout = Math.round(random * Math.max(opts.minTimeout, 1) * Math.pow(opts.factor, attempt));
+  timeout = Math.min(timeout, opts.maxTimeout);
+
+  return timeout;
+};
+
+exports.wrap = function(obj, options, methods) {
+  if (options instanceof Array) {
+    methods = options;
+    options = null;
+  }
+
+  if (!methods) {
+    methods = [];
+    for (var key in obj) {
+      if (typeof obj[key] === 'function') {
+        methods.push(key);
+      }
+    }
+  }
+
+  for (var i = 0; i < methods.length; i++) {
+    var method   = methods[i];
+    var original = obj[method];
+
+    obj[method] = function retryWrapper(original) {
+      var op       = exports.operation(options);
+      var args     = Array.prototype.slice.call(arguments, 1);
+      var callback = args.pop();
+
+      args.push(function(err) {
+        if (op.retry(err)) {
+          return;
+        }
+        if (err) {
+          arguments[0] = op.mainError();
+        }
+        callback.apply(this, arguments);
+      });
+
+      op.attempt(function() {
+        original.apply(obj, args);
+      });
+    }.bind(obj, original);
+    obj[method].options = options;
+  }
+};

--- a/prebuild/node_modules/retry/lib/retry_operation.js
+++ b/prebuild/node_modules/retry/lib/retry_operation.js
@@ -1,0 +1,162 @@
+function RetryOperation(timeouts, options) {
+  // Compatibility for the old (timeouts, retryForever) signature
+  if (typeof options === 'boolean') {
+    options = { forever: options };
+  }
+
+  this._originalTimeouts = JSON.parse(JSON.stringify(timeouts));
+  this._timeouts = timeouts;
+  this._options = options || {};
+  this._maxRetryTime = options && options.maxRetryTime || Infinity;
+  this._fn = null;
+  this._errors = [];
+  this._attempts = 1;
+  this._operationTimeout = null;
+  this._operationTimeoutCb = null;
+  this._timeout = null;
+  this._operationStart = null;
+  this._timer = null;
+
+  if (this._options.forever) {
+    this._cachedTimeouts = this._timeouts.slice(0);
+  }
+}
+module.exports = RetryOperation;
+
+RetryOperation.prototype.reset = function() {
+  this._attempts = 1;
+  this._timeouts = this._originalTimeouts.slice(0);
+}
+
+RetryOperation.prototype.stop = function() {
+  if (this._timeout) {
+    clearTimeout(this._timeout);
+  }
+  if (this._timer) {
+    clearTimeout(this._timer);
+  }
+
+  this._timeouts       = [];
+  this._cachedTimeouts = null;
+};
+
+RetryOperation.prototype.retry = function(err) {
+  if (this._timeout) {
+    clearTimeout(this._timeout);
+  }
+
+  if (!err) {
+    return false;
+  }
+  var currentTime = new Date().getTime();
+  if (err && currentTime - this._operationStart >= this._maxRetryTime) {
+    this._errors.push(err);
+    this._errors.unshift(new Error('RetryOperation timeout occurred'));
+    return false;
+  }
+
+  this._errors.push(err);
+
+  var timeout = this._timeouts.shift();
+  if (timeout === undefined) {
+    if (this._cachedTimeouts) {
+      // retry forever, only keep last error
+      this._errors.splice(0, this._errors.length - 1);
+      timeout = this._cachedTimeouts.slice(-1);
+    } else {
+      return false;
+    }
+  }
+
+  var self = this;
+  this._timer = setTimeout(function() {
+    self._attempts++;
+
+    if (self._operationTimeoutCb) {
+      self._timeout = setTimeout(function() {
+        self._operationTimeoutCb(self._attempts);
+      }, self._operationTimeout);
+
+      if (self._options.unref) {
+          self._timeout.unref();
+      }
+    }
+
+    self._fn(self._attempts);
+  }, timeout);
+
+  if (this._options.unref) {
+      this._timer.unref();
+  }
+
+  return true;
+};
+
+RetryOperation.prototype.attempt = function(fn, timeoutOps) {
+  this._fn = fn;
+
+  if (timeoutOps) {
+    if (timeoutOps.timeout) {
+      this._operationTimeout = timeoutOps.timeout;
+    }
+    if (timeoutOps.cb) {
+      this._operationTimeoutCb = timeoutOps.cb;
+    }
+  }
+
+  var self = this;
+  if (this._operationTimeoutCb) {
+    this._timeout = setTimeout(function() {
+      self._operationTimeoutCb();
+    }, self._operationTimeout);
+  }
+
+  this._operationStart = new Date().getTime();
+
+  this._fn(this._attempts);
+};
+
+RetryOperation.prototype.try = function(fn) {
+  console.log('Using RetryOperation.try() is deprecated');
+  this.attempt(fn);
+};
+
+RetryOperation.prototype.start = function(fn) {
+  console.log('Using RetryOperation.start() is deprecated');
+  this.attempt(fn);
+};
+
+RetryOperation.prototype.start = RetryOperation.prototype.try;
+
+RetryOperation.prototype.errors = function() {
+  return this._errors;
+};
+
+RetryOperation.prototype.attempts = function() {
+  return this._attempts;
+};
+
+RetryOperation.prototype.mainError = function() {
+  if (this._errors.length === 0) {
+    return null;
+  }
+
+  var counts = {};
+  var mainError = null;
+  var mainErrorCount = 0;
+
+  for (var i = 0; i < this._errors.length; i++) {
+    var error = this._errors[i];
+    var message = error.message;
+    var count = (counts[message] || 0) + 1;
+
+    counts[message] = count;
+
+    if (count >= mainErrorCount) {
+      mainError = error;
+      mainErrorCount = count;
+    }
+  }
+
+  return mainError;
+};

--- a/prebuild/node_modules/retry/package.json
+++ b/prebuild/node_modules/retry/package.json
@@ -1,0 +1,36 @@
+{
+  "author": "Tim Koschützki <tim@debuggable.com> (http://debuggable.com/)",
+  "name": "retry",
+  "description": "Abstraction for exponential and custom retry strategies for failed operations.",
+  "license": "MIT",
+  "version": "0.13.1",
+  "homepage": "https://github.com/tim-kos/node-retry",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/tim-kos/node-retry.git"
+  },
+  "files": [
+    "lib",
+    "example"
+  ],
+  "directories": {
+    "lib": "./lib"
+  },
+  "main": "index.js",
+  "engines": {
+    "node": ">= 4"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "fake": "0.2.0",
+    "istanbul": "^0.4.5",
+    "tape": "^4.8.0"
+  },
+  "scripts": {
+    "test": "./node_modules/.bin/istanbul cover ./node_modules/tape/bin/tape ./test/integration/*.js",
+    "release:major": "env SEMANTIC=major npm run release",
+    "release:minor": "env SEMANTIC=minor npm run release",
+    "release:patch": "env SEMANTIC=patch npm run release",
+    "release": "npm version ${SEMANTIC:-patch} -m \"Release %s\" && git push && git push --tags && npm publish"
+  }
+}

--- a/prebuild/package.json
+++ b/prebuild/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "dependencies": {
+    "retry": "^0.13.1",
     "semver": "^7.3.5"
   },
   "devDependencies": {

--- a/prebuild/targets.js
+++ b/prebuild/targets.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const semver = require("semver");
+
 const nodeTargets = [
   { version: "12.0.0", abi: "72" },
   { version: "13.0.0", abi: "79" },
@@ -12,4 +14,10 @@ const nodeTargets = [
   { version: "20.0.0", abi: "115" },
 ];
 
-module.exports = { nodeTargets };
+function getFilteredNodeTargets(semverConstraint) {
+  return nodeTargets.filter((target) =>
+    semver.satisfies(target.version, semverConstraint)
+  );
+}
+
+module.exports = { getFilteredNodeTargets };

--- a/prebuild/targets.js
+++ b/prebuild/targets.js
@@ -1,0 +1,15 @@
+"use strict";
+
+const nodeTargets = [
+  { version: "12.0.0", abi: "72" },
+  { version: "13.0.0", abi: "79" },
+  { version: "14.0.0", abi: "83" },
+  { version: "15.0.0", abi: "88" },
+  { version: "16.0.0", abi: "93" },
+  { version: "17.0.1", abi: "102" },
+  { version: "18.0.0", abi: "108" },
+  { version: "19.0.0", abi: "111" },
+  { version: "20.0.0", abi: "115" },
+];
+
+module.exports = { nodeTargets };

--- a/prebuild/yarn.lock
+++ b/prebuild/yarn.lock
@@ -14,6 +14,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+retry@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
+
 semver@^7.3.5:
   version "7.3.7"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"


### PR DESCRIPTION
nodejs.org often fails with 500 errors and make the build fails. This commit adds a new fetch_node_header.js script with a retry mechanism and cache the headers.
The key for the cache is OS + minimun node version + hash of all targeted node versions.