### PR TITLE
Install node-gyp before fetching the headers.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@6a862e9b80fcf19ead110e5ee966996055316c37
 
   linux-x64:
     if: ${{ !contains(inputs.skip, 'linux-x64') }}
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@6a862e9b80fcf19ead110e5ee966996055316c37
 
   linux-arm64:
     if: ${{ !contains(inputs.skip, 'linux-arm64') }}
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@6a862e9b80fcf19ead110e5ee966996055316c37
 
   linux-arm:
     if: ${{ !contains(inputs.skip, 'linux-arm') }}
@@ -133,7 +133,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@6a862e9b80fcf19ead110e5ee966996055316c37
 
   linuxmusl-x64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
@@ -149,7 +149,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@6a862e9b80fcf19ead110e5ee966996055316c37
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
 
@@ -166,7 +166,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@6a862e9b80fcf19ead110e5ee966996055316c37
 
   windows:
     strategy:
@@ -181,7 +181,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@6a862e9b80fcf19ead110e5ee966996055316c37
 
   # Tests
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@6a862e9b80fcf19ead110e5ee966996055316c37
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-x64:
     if: ${{ !contains(inputs.skip, 'linux-x64') }}
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@6a862e9b80fcf19ead110e5ee966996055316c37
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-arm64:
     if: ${{ !contains(inputs.skip, 'linux-arm64') }}
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@6a862e9b80fcf19ead110e5ee966996055316c37
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-arm:
     if: ${{ !contains(inputs.skip, 'linux-arm') }}
@@ -133,7 +133,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@6a862e9b80fcf19ead110e5ee966996055316c37
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxmusl-x64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
@@ -149,7 +149,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@6a862e9b80fcf19ead110e5ee966996055316c37
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
 
@@ -166,7 +166,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@6a862e9b80fcf19ead110e5ee966996055316c37
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   windows:
     strategy:
@@ -181,7 +181,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@6a862e9b80fcf19ead110e5ee966996055316c37
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # Tests
 

--- a/prebuild/action.yml
+++ b/prebuild/action.yml
@@ -5,12 +5,13 @@ runs:
     - name: Install node-gyp npm
       if: ${{ env.PACKAGE_MANAGER == 'npm' }}
       run: |
-        $PACKAGE_MANAGER install -g node-gyp
+        npm config set unsafe-perm true
+        npm install -g node-gyp
       shell: bash
     - name: Install node-gyp yarn
       if: ${{ env.PACKAGE_MANAGER == 'yarn' }}
       run: |
-        $PACKAGE_MANAGER global add node-gyp --ignore-engines
+        yarn global add node-gyp --ignore-engines
       shell: bash
     - run: |
         $PACKAGE_MANAGER install --ignore-scripts

--- a/prebuild/action.yml
+++ b/prebuild/action.yml
@@ -2,7 +2,18 @@ runs:
   using: composite
   steps:
     - uses: actions/download-artifact@v3
-    - run: $PACKAGE_MANAGER install --ignore-scripts
+    - name: Install node-gyp npm
+      if: ${{ env.PACKAGE_MANAGER == 'npm' }}
+      run: |
+        $PACKAGE_MANAGER install -g node-gyp
+      shell: bash
+    - name: Install node-gyp yarn
+      if: ${{ env.PACKAGE_MANAGER == 'yarn' }}
+      run: |
+        $PACKAGE_MANAGER global add node-gyp --ignore-engines
+      shell: bash
+    - run: |
+        $PACKAGE_MANAGER install --ignore-scripts
       shell: bash
       working-directory: ${{ env.DIRECTORY_PATH }}
     - run: |


### PR DESCRIPTION
node-gyp is not part of the runner OS installation so trying to fetch the headers when the cache is disabled fails because of the binary is not found.