### PR TITLE
fix windows rustup race condition on self update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - id: versions
-        uses: DataDog/action-prebuildify/compute-matrix@fix-windows-rust-race
+        uses: DataDog/action-prebuildify/compute-matrix@main
         with:
           min: ${{ inputs.min-node-version }}
 
@@ -112,7 +112,7 @@ jobs:
         with:
           node-version: '18'
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/prebuild@fix-windows-rust-race
+      - uses: DataDog/action-prebuildify/prebuild@main
         # Otherwise hangs for 6h sometimes. Remove when no longer happening.
         timeout-minutes: 10
 
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@fix-windows-rust-race
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-x64:
     if: ${{ !contains(inputs.skip, 'linux-x64') }}
@@ -141,7 +141,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@fix-windows-rust-race
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxmusl-x64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
@@ -158,7 +158,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@fix-windows-rust-race
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
 
@@ -175,7 +175,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@fix-windows-rust-race
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   windows:
     strategy:
@@ -190,7 +190,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@fix-windows-rust-race
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # Tests
 
@@ -210,7 +210,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/test@fix-windows-rust-race
+      - uses: DataDog/action-prebuildify/test@main
 
   linux-test:
     strategy:
@@ -225,7 +225,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/test@fix-windows-rust-race
+      - uses: DataDog/action-prebuildify/test@main
 
   macos-x64-test:
     strategy:
@@ -269,7 +269,7 @@ jobs:
         if: ${{ matrix.node <= '14' }}
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@fix-windows-rust-race
+      - uses: DataDog/action-prebuildify/test@main
 
   windows-test:
     strategy:
@@ -288,4 +288,4 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@fix-windows-rust-race
+      - uses: DataDog/action-prebuildify/test@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - id: versions
-        uses: DataDog/action-prebuildify/compute-matrix@main
+        uses: DataDog/action-prebuildify/compute-matrix@fix-windows-rust-race
         with:
           min: ${{ inputs.min-node-version }}
 
@@ -112,7 +112,7 @@ jobs:
         with:
           node-version: '18'
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@fix-windows-rust-race
         # Otherwise hangs for 6h sometimes. Remove when no longer happening.
         timeout-minutes: 10
 
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@fix-windows-rust-race
 
   linux-x64:
     if: ${{ !contains(inputs.skip, 'linux-x64') }}
@@ -141,7 +141,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@fix-windows-rust-race
 
   linuxmusl-x64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
@@ -158,7 +158,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@fix-windows-rust-race
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
 
@@ -175,7 +175,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@fix-windows-rust-race
 
   windows:
     strategy:
@@ -190,7 +190,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@fix-windows-rust-race
 
   # Tests
 
@@ -210,7 +210,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@fix-windows-rust-race
 
   linux-test:
     strategy:
@@ -225,7 +225,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@fix-windows-rust-race
 
   macos-x64-test:
     strategy:
@@ -269,7 +269,7 @@ jobs:
         if: ${{ matrix.node <= '14' }}
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@fix-windows-rust-race
 
   windows-test:
     strategy:
@@ -288,4 +288,4 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@fix-windows-rust-race

--- a/prebuild/index.js
+++ b/prebuild/index.js
@@ -129,8 +129,6 @@ function installRust () {
 
   process.env.PATH += path.delimiter + process.env.HOME + path.sep + '.cargo' + path.sep + 'bin'
   process.env.CARGO_BUILD_TARGET = target
-  process.env.RUSTUP_TOOLCHAIN = 'nightly'
-  // process.env.RUSTUP_UPDATE_ROOT = 'https://dev-static.rust-lang.org/rustup'
 
   if (platform === 'linux' && libc === 'musl') {
     process.env.RUSTFLAGS = '-C target-feature=-crt-static'
@@ -140,10 +138,9 @@ function installRust () {
   // installed, for example on GitHub Actions Windows runners.
   execSync([
     "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs",
-    `sh -s -- -y --verbose --default-host ${target} --default-toolchain nightly`
+    `sh -s -- -y --verbose --default-host ${target}`
   ].join(' | '), { stdio, shell })
 
-  // TODO: Switch back to stable toolchain when build-std becomes stable.
-  execSync('rustup toolchain install nightly && rustup default nightly', { stdio, shell })
-  execSync('rustup component add rust-src', { stdio, shell })
+  execSync('rustup toolchain install nightly --no-self-update', { stdio, shell })
+  execSync('rustup component add rust-src --toolchain nightly', { stdio, shell })
 }


### PR DESCRIPTION
`rustup` doesn't support self-updating on Windows, yet for some reason it still attempts it by default, resulting in hitting https://github.com/rust-lang/rustup/issues/2441. This PR disables this behaviour as it's not needed for CI anyway.

Working CI: https://github.com/DataDog/action-prebuildify/actions/runs/8318895142

I also ran CI 3 times to make sure the issue is completely fixed as it was previously flaky (although failing more than 50% of the time).