### PR TITLE
fix broken filter for linux arm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
+        with:
+          node-version: 18
       - run: npm i -g yarn
       - uses: DataDog/action-prebuildify/docker@fix-skip-linux-arm
       - uses: DataDog/action-prebuildify/prebuild@fix-skip-linux-arm
@@ -113,6 +115,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
+        with:
+          node-version: 18
       - run: npm i -g yarn
       - uses: DataDog/action-prebuildify/docker@fix-skip-linux-arm
       - uses: DataDog/action-prebuildify/prebuild@fix-skip-linux-arm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,34 +87,31 @@ jobs:
           min: ${{ inputs.min-node-version }}
 
   # TODO: Add tests when out of beta and we have more ARM runners available.
-  linux:
-    strategy:
-      matrix:
-        arch: [ {node: arm64, docker: arm64v8}, {node: arm, docker: arm32v7} ]
-    if: ${{ !contains(inputs.skip, 'linux-${{ matrix.arch.node }}') }}
+  linux-arm:
+    if: ${{ !contains(inputs.skip, 'linux-arm') }}
     runs-on: arm-4core-linux
-    name: linux-${{ matrix.arch.node }}
+    name: linux-arm
     env:
-      ARCH: ${{ matrix.arch.node }}
-      DOCKER_BUILDER: rochdev/holy-node-box:12-${{ matrix.arch.docker }}
+      ARCH: arm
+      DOCKER_BUILDER: rochdev/holy-node-box:12-arm32v7
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
-      - run: |
-          curl -fsSL https://get.docker.com -o get-docker.sh
-          sudo sh ./get-docker.sh
-      - run: |
-          sudo usermod -aG docker $USER
-          sudo apt-get install acl
-          sudo setfacl --modify user:$USER:rw /var/run/docker.sock
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-      - run: npm i -g yarn
+      - uses: DataDog/action-prebuildify/docker@main
       - uses: DataDog/action-prebuildify/prebuild@main
         # Otherwise hangs for 6h sometimes. Remove when no longer happening.
         timeout-minutes: 10
+
+  linux-arm64:
+    if: ${{ !contains(inputs.skip, 'linux-arm64') }}
+    runs-on: arm-4core-linux
+    name: linux-arm64
+    env:
+      ARCH: arm64
+      DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8
+    steps:
+      - uses: actions/checkout@v3
+      - uses: DataDog/action-prebuildify/docker@main
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-ia32:
     if: ${{ !contains(inputs.skip, 'linux-ia32') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - id: versions
-        uses: DataDog/action-prebuildify/compute-matrix@fix-skip-linux-arm
+        uses: DataDog/action-prebuildify/compute-matrix@main
         with:
           min: ${{ inputs.min-node-version }}
 
@@ -100,8 +100,8 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/docker@fix-skip-linux-arm
-      - uses: DataDog/action-prebuildify/prebuild@fix-skip-linux-arm
+      - uses: DataDog/action-prebuildify/docker@main
+      - uses: DataDog/action-prebuildify/prebuild@main
         # Otherwise hangs for 6h sometimes. Remove when no longer happening.
         timeout-minutes: 10
 
@@ -118,8 +118,8 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/docker@fix-skip-linux-arm
-      - uses: DataDog/action-prebuildify/prebuild@fix-skip-linux-arm
+      - uses: DataDog/action-prebuildify/docker@main
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-ia32:
     if: ${{ !contains(inputs.skip, 'linux-ia32') }}
@@ -133,7 +133,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@fix-skip-linux-arm
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-x64:
     if: ${{ !contains(inputs.skip, 'linux-x64') }}
@@ -146,7 +146,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@fix-skip-linux-arm
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxmusl-x64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
@@ -163,7 +163,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@fix-skip-linux-arm
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
 
@@ -180,7 +180,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@fix-skip-linux-arm
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   windows:
     strategy:
@@ -195,7 +195,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@fix-skip-linux-arm
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # Tests
 
@@ -215,7 +215,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/test@fix-skip-linux-arm
+      - uses: DataDog/action-prebuildify/test@main
 
   linux-test:
     strategy:
@@ -230,7 +230,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/test@fix-skip-linux-arm
+      - uses: DataDog/action-prebuildify/test@main
 
   macos-x64-test:
     strategy:
@@ -274,7 +274,7 @@ jobs:
         if: ${{ matrix.node <= '14' }}
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@fix-skip-linux-arm
+      - uses: DataDog/action-prebuildify/test@main
 
   windows-test:
     strategy:
@@ -293,4 +293,4 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@fix-skip-linux-arm
+      - uses: DataDog/action-prebuildify/test@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - id: versions
-        uses: DataDog/action-prebuildify/compute-matrix@main
+        uses: DataDog/action-prebuildify/compute-matrix@fix-skip-linux-arm
         with:
           min: ${{ inputs.min-node-version }}
 
@@ -96,8 +96,8 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm32v7
     steps:
       - uses: actions/checkout@v3
-      - uses: DataDog/action-prebuildify/docker@main
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/docker@fix-skip-linux-arm
+      - uses: DataDog/action-prebuildify/prebuild@fix-skip-linux-arm
         # Otherwise hangs for 6h sometimes. Remove when no longer happening.
         timeout-minutes: 10
 
@@ -110,8 +110,8 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8
     steps:
       - uses: actions/checkout@v3
-      - uses: DataDog/action-prebuildify/docker@main
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/docker@fix-skip-linux-arm
+      - uses: DataDog/action-prebuildify/prebuild@fix-skip-linux-arm
 
   linux-ia32:
     if: ${{ !contains(inputs.skip, 'linux-ia32') }}
@@ -125,7 +125,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@fix-skip-linux-arm
 
   linux-x64:
     if: ${{ !contains(inputs.skip, 'linux-x64') }}
@@ -138,7 +138,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@fix-skip-linux-arm
 
   linuxmusl-x64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
@@ -155,7 +155,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@fix-skip-linux-arm
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
 
@@ -172,7 +172,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@fix-skip-linux-arm
 
   windows:
     strategy:
@@ -187,7 +187,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@fix-skip-linux-arm
 
   # Tests
 
@@ -207,7 +207,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@fix-skip-linux-arm
 
   linux-test:
     strategy:
@@ -222,7 +222,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@fix-skip-linux-arm
 
   macos-x64-test:
     strategy:
@@ -266,7 +266,7 @@ jobs:
         if: ${{ matrix.node <= '14' }}
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@fix-skip-linux-arm
 
   windows-test:
     strategy:
@@ -285,4 +285,4 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@fix-skip-linux-arm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm32v7
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
       - uses: DataDog/action-prebuildify/docker@fix-skip-linux-arm
       - uses: DataDog/action-prebuildify/prebuild@fix-skip-linux-arm
         # Otherwise hangs for 6h sometimes. Remove when no longer happening.
@@ -110,6 +111,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
       - uses: DataDog/action-prebuildify/docker@fix-skip-linux-arm
       - uses: DataDog/action-prebuildify/prebuild@fix-skip-linux-arm
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
+      - run: npm i -g yarn
       - uses: DataDog/action-prebuildify/docker@fix-skip-linux-arm
       - uses: DataDog/action-prebuildify/prebuild@fix-skip-linux-arm
         # Otherwise hangs for 6h sometimes. Remove when no longer happening.
@@ -112,6 +113,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
+      - run: npm i -g yarn
       - uses: DataDog/action-prebuildify/docker@fix-skip-linux-arm
       - uses: DataDog/action-prebuildify/prebuild@fix-skip-linux-arm
 

--- a/docker/action.yml
+++ b/docker/action.yml
@@ -1,0 +1,13 @@
+name: Install Docker
+runs:
+  using: composite
+  steps:
+    - run: |
+        curl -fsSL https://get.docker.com -o get-docker.sh
+        sudo sh ./get-docker.sh
+      shell: bash
+    - run: |
+        sudo usermod -aG docker $USER
+        sudo apt-get install acl
+        sudo setfacl --modify user:$USER:rw /var/run/docker.sock
+      shell: bash


### PR DESCRIPTION
Jobs using a matrix are not compatible with conditional runs, which broke skipping Linux ARM jobs.

Working CI: https://github.com/DataDog/action-prebuildify/actions/runs/8396262487