### PR TITLE
fix skipping macos and windows builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,30 +167,46 @@ jobs:
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
 
-  macos:
-    strategy:
-      matrix:
-        arch: ['arm64', 'x64']
-    if: ${{ !contains(inputs.skip, 'macos-${{ matrix.arch }}') }}
+  macos-arm64:
+    if: ${{ !contains(inputs.skip, 'macos-arm64') }}
     runs-on: macos-11
-    name: macos-${{ matrix.arch }}
+    name: macos-arm64
     env:
-      ARCH: ${{ matrix.arch }}
+      ARCH: arm64
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: true
       - uses: DataDog/action-prebuildify/prebuild@main
 
-  windows:
-    strategy:
-      matrix:
-        arch: ['ia32', 'x64']
-    if: ${{ !contains(inputs.skip, 'windows-${{ matrix.arch }}') }}
-    runs-on: windows-2019
-    name: windows-${{ matrix.arch }}
+  macos-x64:
+    if: ${{ !contains(inputs.skip, 'macos-x64') }}
+    runs-on: macos-11
+    name: macos-x64
     env:
-      ARCH: ${{ matrix.arch }}
+      ARCH: x64
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: DataDog/action-prebuildify/prebuild@main
+
+  windows-ia32:
+    if: ${{ !contains(inputs.skip, 'windows-ia32') }}
+    runs-on: windows-2019
+    env:
+      ARCH: ia32
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: DataDog/action-prebuildify/prebuild@main
+
+  windows-x64:
+    if: ${{ !contains(inputs.skip, 'windows-x64') }}
+    runs-on: windows-2019
+    env:
+      ARCH: x64
     steps:
       - uses: actions/checkout@v3
         with:
@@ -238,7 +254,7 @@ jobs:
         node: ${{ fromJson(needs.versions.outputs.versions) }}
     needs:
       - versions
-      - macos
+      - macos-x64
     runs-on: macos-11
     name: macos-x64-test-${{ matrix.node }}
     steps:
@@ -282,7 +298,7 @@ jobs:
         node: ${{ fromJson(needs.versions.outputs.versions) }}
     needs:
       - versions
-      - windows
+      - windows-x64
     runs-on: windows-2019
     name: windows-test-${{ matrix.node }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - id: versions
-        uses: DataDog/action-prebuildify/compute-matrix@main
+        uses: DataDog/action-prebuildify/compute-matrix@fix-skip-mac-win
         with:
           min: ${{ inputs.min-node-version }}
 
@@ -100,8 +100,8 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/docker@main
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/docker@fix-skip-mac-win
+      - uses: DataDog/action-prebuildify/prebuild@fix-skip-mac-win
         # Otherwise hangs for 6h sometimes. Remove when no longer happening.
         timeout-minutes: 10
 
@@ -118,8 +118,8 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/docker@main
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/docker@fix-skip-mac-win
+      - uses: DataDog/action-prebuildify/prebuild@fix-skip-mac-win
 
   linux-ia32:
     if: ${{ !contains(inputs.skip, 'linux-ia32') }}
@@ -133,7 +133,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@fix-skip-mac-win
 
   linux-x64:
     if: ${{ !contains(inputs.skip, 'linux-x64') }}
@@ -146,7 +146,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@fix-skip-mac-win
 
   linuxmusl-x64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
@@ -163,7 +163,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@fix-skip-mac-win
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
 
@@ -177,7 +177,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@fix-skip-mac-win
 
   macos-x64:
     if: ${{ !contains(inputs.skip, 'macos-x64') }}
@@ -189,7 +189,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@fix-skip-mac-win
 
   windows-ia32:
     if: ${{ !contains(inputs.skip, 'windows-ia32') }}
@@ -200,7 +200,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@fix-skip-mac-win
 
   windows-x64:
     if: ${{ !contains(inputs.skip, 'windows-x64') }}
@@ -211,7 +211,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@fix-skip-mac-win
 
   # Tests
 
@@ -231,7 +231,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@fix-skip-mac-win
 
   linux-test:
     strategy:
@@ -246,7 +246,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@fix-skip-mac-win
 
   macos-x64-test:
     strategy:
@@ -290,7 +290,7 @@ jobs:
         if: ${{ matrix.node <= '14' }}
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@fix-skip-mac-win
 
   windows-test:
     strategy:
@@ -309,4 +309,4 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@fix-skip-mac-win

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - id: versions
-        uses: DataDog/action-prebuildify/compute-matrix@fix-skip-mac-win
+        uses: DataDog/action-prebuildify/compute-matrix@main
         with:
           min: ${{ inputs.min-node-version }}
 
@@ -100,8 +100,8 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/docker@fix-skip-mac-win
-      - uses: DataDog/action-prebuildify/prebuild@fix-skip-mac-win
+      - uses: DataDog/action-prebuildify/docker@main
+      - uses: DataDog/action-prebuildify/prebuild@main
         # Otherwise hangs for 6h sometimes. Remove when no longer happening.
         timeout-minutes: 10
 
@@ -118,8 +118,8 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/docker@fix-skip-mac-win
-      - uses: DataDog/action-prebuildify/prebuild@fix-skip-mac-win
+      - uses: DataDog/action-prebuildify/docker@main
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-ia32:
     if: ${{ !contains(inputs.skip, 'linux-ia32') }}
@@ -131,7 +131,7 @@ jobs:
     steps:
       - uses: docker/setup-qemu-action@v2
       - uses: actions/checkout@v3
-      - uses: DataDog/action-prebuildify/prebuild@fix-skip-mac-win
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-x64:
     if: ${{ !contains(inputs.skip, 'linux-x64') }}
@@ -142,7 +142,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@v3
-      - uses: DataDog/action-prebuildify/prebuild@fix-skip-mac-win
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxmusl-x64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
@@ -157,7 +157,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl tar zstd
       - uses: actions/checkout@v3
-      - uses: DataDog/action-prebuildify/prebuild@fix-skip-mac-win
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
 
@@ -168,7 +168,7 @@ jobs:
       ARCH: arm64
     steps:
       - uses: actions/checkout@v3
-      - uses: DataDog/action-prebuildify/prebuild@fix-skip-mac-win
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   macos-x64:
     if: ${{ !contains(inputs.skip, 'macos-x64') }}
@@ -177,7 +177,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v3
-      - uses: DataDog/action-prebuildify/prebuild@fix-skip-mac-win
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   windows-ia32:
     if: ${{ !contains(inputs.skip, 'windows-ia32') }}
@@ -186,7 +186,7 @@ jobs:
       ARCH: ia32
     steps:
       - uses: actions/checkout@v3
-      - uses: DataDog/action-prebuildify/prebuild@fix-skip-mac-win
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   windows-x64:
     if: ${{ !contains(inputs.skip, 'windows-x64') }}
@@ -195,7 +195,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v3
-      - uses: DataDog/action-prebuildify/prebuild@fix-skip-mac-win
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # Tests
 
@@ -213,7 +213,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl
       - uses: actions/checkout@v3
-      - uses: DataDog/action-prebuildify/test@fix-skip-mac-win
+      - uses: DataDog/action-prebuildify/test@main
 
   linux-test:
     strategy:
@@ -226,7 +226,7 @@ jobs:
     name: linux-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3
-      - uses: DataDog/action-prebuildify/test@fix-skip-mac-win
+      - uses: DataDog/action-prebuildify/test@main
 
   macos-x64-test:
     strategy:
@@ -268,7 +268,7 @@ jobs:
         if: ${{ matrix.node <= '14' }}
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@fix-skip-mac-win
+      - uses: DataDog/action-prebuildify/test@main
 
   windows-test:
     strategy:
@@ -285,4 +285,4 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@fix-skip-mac-win
+      - uses: DataDog/action-prebuildify/test@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,8 +131,6 @@ jobs:
     steps:
       - uses: docker/setup-qemu-action@v2
       - uses: actions/checkout@v3
-        with:
-          submodules: true
       - uses: DataDog/action-prebuildify/prebuild@fix-skip-mac-win
 
   linux-x64:
@@ -144,8 +142,6 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
       - uses: DataDog/action-prebuildify/prebuild@fix-skip-mac-win
 
   linuxmusl-x64:
@@ -161,8 +157,6 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl tar zstd
       - uses: actions/checkout@v3
-        with:
-          submodules: true
       - uses: DataDog/action-prebuildify/prebuild@fix-skip-mac-win
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
@@ -170,25 +164,19 @@ jobs:
   macos-arm64:
     if: ${{ !contains(inputs.skip, 'macos-arm64') }}
     runs-on: macos-11
-    name: macos-arm64
     env:
       ARCH: arm64
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
       - uses: DataDog/action-prebuildify/prebuild@fix-skip-mac-win
 
   macos-x64:
     if: ${{ !contains(inputs.skip, 'macos-x64') }}
     runs-on: macos-11
-    name: macos-x64
     env:
       ARCH: x64
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
       - uses: DataDog/action-prebuildify/prebuild@fix-skip-mac-win
 
   windows-ia32:
@@ -198,8 +186,6 @@ jobs:
       ARCH: ia32
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
       - uses: DataDog/action-prebuildify/prebuild@fix-skip-mac-win
 
   windows-x64:
@@ -209,8 +195,6 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
       - uses: DataDog/action-prebuildify/prebuild@fix-skip-mac-win
 
   # Tests
@@ -229,8 +213,6 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl
       - uses: actions/checkout@v3
-        with:
-          submodules: true
       - uses: DataDog/action-prebuildify/test@fix-skip-mac-win
 
   linux-test:
@@ -244,8 +226,6 @@ jobs:
     name: linux-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
       - uses: DataDog/action-prebuildify/test@fix-skip-mac-win
 
   macos-x64-test:
@@ -259,8 +239,6 @@ jobs:
     name: macos-x64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
@@ -303,8 +281,6 @@ jobs:
     name: windows-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}


### PR DESCRIPTION
Same as #41 but for Windows and macOS.

Working CI: https://github.com/DataDog/action-prebuildify/actions/runs/8429852940