### PR TITLE
fix race condition when downloading artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -310,4 +310,4 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: prebuilds
-          path: ${{ env.DIRECTORY_PATH }}/prebuilds/**/*
+          path: ${{ env.DIRECTORY_PATH }}/**/prebuilds/**/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -286,3 +286,27 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
       - uses: DataDog/action-prebuildify/test@main
+
+  # Prebuilds
+
+  prebuilds:
+    needs:
+      - linux-arm
+      - linux-arm64
+      - linux-ia32
+      - linuxmusl-x64
+      - linux-x64
+      - macos-arm64
+      - macos-x64
+      - windows-ia32
+      - windows-x64
+    runs-on: ubuntu-latest
+    name: prebuilds
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: ${{ env.DIRECTORY_PATH }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: prebuilds
+          path: ${{ env.DIRECTORY_PATH }}/prebuilds/**/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -306,6 +306,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: ${{ env.DIRECTORY_PATH }}
+          merge-multiple: true
       - uses: actions/upload-artifact@v4
         with:
           name: prebuilds

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - id: versions
-        uses: DataDog/action-prebuildify/compute-matrix@fix-artifact-not-found
+        uses: DataDog/action-prebuildify/compute-matrix@main
         with:
           min: ${{ inputs.min-node-version }}
 
@@ -100,8 +100,8 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/docker@fix-artifact-not-found
-      - uses: DataDog/action-prebuildify/prebuild@fix-artifact-not-found
+      - uses: DataDog/action-prebuildify/docker@main
+      - uses: DataDog/action-prebuildify/prebuild@main
         # Otherwise hangs for 6h sometimes. Remove when no longer happening.
         timeout-minutes: 10
 
@@ -118,8 +118,8 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/docker@fix-artifact-not-found
-      - uses: DataDog/action-prebuildify/prebuild@fix-artifact-not-found
+      - uses: DataDog/action-prebuildify/docker@main
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-ia32:
     if: ${{ !contains(inputs.skip, 'linux-ia32') }}
@@ -131,7 +131,7 @@ jobs:
     steps:
       - uses: docker/setup-qemu-action@v3
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@fix-artifact-not-found
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-x64:
     if: ${{ !contains(inputs.skip, 'linux-x64') }}
@@ -142,7 +142,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@fix-artifact-not-found
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxmusl-x64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
@@ -157,7 +157,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl tar zstd
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@fix-artifact-not-found
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
 
@@ -168,7 +168,7 @@ jobs:
       ARCH: arm64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@fix-artifact-not-found
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   macos-x64:
     if: ${{ !contains(inputs.skip, 'macos-x64') }}
@@ -177,7 +177,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@fix-artifact-not-found
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   windows-ia32:
     if: ${{ !contains(inputs.skip, 'windows-ia32') }}
@@ -186,7 +186,7 @@ jobs:
       ARCH: ia32
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@fix-artifact-not-found
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   windows-x64:
     if: ${{ !contains(inputs.skip, 'windows-x64') }}
@@ -195,7 +195,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@fix-artifact-not-found
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # Tests
 
@@ -213,7 +213,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@fix-artifact-not-found
+      - uses: DataDog/action-prebuildify/test@main
 
   linux-test:
     strategy:
@@ -226,7 +226,7 @@ jobs:
     name: linux-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@fix-artifact-not-found
+      - uses: DataDog/action-prebuildify/test@main
 
   macos-x64-test:
     strategy:
@@ -268,7 +268,7 @@ jobs:
         if: ${{ matrix.node <= '14' }}
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@fix-artifact-not-found
+      - uses: DataDog/action-prebuildify/test@main
 
   windows-test:
     strategy:
@@ -285,7 +285,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@fix-artifact-not-found
+      - uses: DataDog/action-prebuildify/test@main
 
   # Prebuilds
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
       ARCH: arm
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm32v7
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -113,7 +113,7 @@ jobs:
       ARCH: arm64
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -129,8 +129,8 @@ jobs:
       ARCH: ia32
       DOCKER_BUILDER: rochdev/holy-node-box:12-i386
     steps:
-      - uses: docker/setup-qemu-action@v2
-      - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v3
+      - uses: actions/checkout@v4
       - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-x64:
@@ -141,7 +141,7 @@ jobs:
       ARCH: x64
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxmusl-x64:
@@ -156,7 +156,7 @@ jobs:
       LIBC: musl
     steps:
       - run: apk update && apk add bash build-base git python3 curl tar zstd
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: DataDog/action-prebuildify/prebuild@main
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
@@ -167,7 +167,7 @@ jobs:
     env:
       ARCH: arm64
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: DataDog/action-prebuildify/prebuild@main
 
   macos-x64:
@@ -176,7 +176,7 @@ jobs:
     env:
       ARCH: x64
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: DataDog/action-prebuildify/prebuild@main
 
   windows-ia32:
@@ -185,7 +185,7 @@ jobs:
     env:
       ARCH: ia32
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: DataDog/action-prebuildify/prebuild@main
 
   windows-x64:
@@ -194,7 +194,7 @@ jobs:
     env:
       ARCH: x64
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: DataDog/action-prebuildify/prebuild@main
 
   # Tests
@@ -212,7 +212,7 @@ jobs:
     name: alpine-test-${{ matrix.node }}
     steps:
       - run: apk update && apk add bash build-base git python3 curl
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: DataDog/action-prebuildify/test@main
 
   linux-test:
@@ -225,7 +225,7 @@ jobs:
     runs-on: ubuntu-latest
     name: linux-test-${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: DataDog/action-prebuildify/test@main
 
   macos-x64-test:
@@ -238,8 +238,8 @@ jobs:
     runs-on: macos-11
     name: macos-x64-test-${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
@@ -280,8 +280,8 @@ jobs:
     runs-on: windows-2019
     name: windows-test-${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - id: versions
-        uses: DataDog/action-prebuildify/compute-matrix@main
+        uses: DataDog/action-prebuildify/compute-matrix@fix-artifact-not-found
         with:
           min: ${{ inputs.min-node-version }}
 
@@ -100,8 +100,8 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/docker@main
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/docker@fix-artifact-not-found
+      - uses: DataDog/action-prebuildify/prebuild@fix-artifact-not-found
         # Otherwise hangs for 6h sometimes. Remove when no longer happening.
         timeout-minutes: 10
 
@@ -118,8 +118,8 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/docker@main
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/docker@fix-artifact-not-found
+      - uses: DataDog/action-prebuildify/prebuild@fix-artifact-not-found
 
   linux-ia32:
     if: ${{ !contains(inputs.skip, 'linux-ia32') }}
@@ -131,7 +131,7 @@ jobs:
     steps:
       - uses: docker/setup-qemu-action@v3
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@fix-artifact-not-found
 
   linux-x64:
     if: ${{ !contains(inputs.skip, 'linux-x64') }}
@@ -142,7 +142,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@fix-artifact-not-found
 
   linuxmusl-x64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
@@ -157,7 +157,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl tar zstd
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@fix-artifact-not-found
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
 
@@ -168,7 +168,7 @@ jobs:
       ARCH: arm64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@fix-artifact-not-found
 
   macos-x64:
     if: ${{ !contains(inputs.skip, 'macos-x64') }}
@@ -177,7 +177,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@fix-artifact-not-found
 
   windows-ia32:
     if: ${{ !contains(inputs.skip, 'windows-ia32') }}
@@ -186,7 +186,7 @@ jobs:
       ARCH: ia32
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@fix-artifact-not-found
 
   windows-x64:
     if: ${{ !contains(inputs.skip, 'windows-x64') }}
@@ -195,7 +195,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@fix-artifact-not-found
 
   # Tests
 
@@ -213,7 +213,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@fix-artifact-not-found
 
   linux-test:
     strategy:
@@ -226,7 +226,7 @@ jobs:
     name: linux-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@fix-artifact-not-found
 
   macos-x64-test:
     strategy:
@@ -268,7 +268,7 @@ jobs:
         if: ${{ matrix.node <= '14' }}
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@fix-artifact-not-found
 
   windows-test:
     strategy:
@@ -285,7 +285,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@fix-artifact-not-found
 
   # Prebuilds
 

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -14,6 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
       - run: yarn install
       - run: yarn lint

--- a/node/12/action.yml
+++ b/node/12/action.yml
@@ -2,7 +2,7 @@ name: Node 12
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: '12'
         cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}

--- a/node/14/action.yml
+++ b/node/14/action.yml
@@ -2,7 +2,7 @@ name: Node 14
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: '14'
         cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}

--- a/node/16/action.yml
+++ b/node/16/action.yml
@@ -2,7 +2,7 @@ name: Node 16
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: '16'
         cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}

--- a/node/18/action.yml
+++ b/node/18/action.yml
@@ -2,7 +2,7 @@ name: Node 18
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: '18'
         cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}

--- a/node/20/action.yml
+++ b/node/20/action.yml
@@ -2,7 +2,7 @@ name: Node 20
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: '20'
         cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}

--- a/prebuild/action.yml
+++ b/prebuild/action.yml
@@ -1,7 +1,7 @@
 runs:
   using: composite
   steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
     - name: Install node-gyp
       run: |
         yarn global add node-gyp --ignore-engines

--- a/prebuild/action.yml
+++ b/prebuild/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Restore node headers
       if: ${{ env.CACHE == 'true' }}
       id: cache-node-headers
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: ${{ env.NODE_HEADERS_DIRECTORY }}
         key: node-headers-cache-${{ runner.os }}-version${{ env.NODE_VERSIONS }}-${{ steps.compute-node-targets-hash.outputs.hash }}

--- a/prebuild/action.yml
+++ b/prebuild/action.yml
@@ -55,7 +55,7 @@ runs:
           /bin/bash -c 'yarn && cd /usr/workspace && yarn exec node /usr/action'
       if: ${{ env.DOCKER_BUILDER != '' }}
       shell: bash
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
-        name: prebuilds
+        name: prebuilds-${{ github.job }}
         path: ${{ env.DIRECTORY_PATH }}/prebuilds/**/*

--- a/prebuild/action.yml
+++ b/prebuild/action.yml
@@ -1,7 +1,6 @@
 runs:
   using: composite
   steps:
-    - uses: actions/download-artifact@v4
     - name: Install node-gyp
       run: |
         yarn global add node-gyp --ignore-engines

--- a/prebuild/action.yml
+++ b/prebuild/action.yml
@@ -57,4 +57,4 @@ runs:
     - uses: actions/upload-artifact@v4
       with:
         name: prebuilds-${{ github.job }}
-        path: ${{ env.DIRECTORY_PATH }}/prebuilds/**/*
+        path: ${{ env.DIRECTORY_PATH }}/**/prebuilds/**/*

--- a/test/action.yml
+++ b/test/action.yml
@@ -1,7 +1,7 @@
 runs:
   using: composite
   steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         path: ${{ env.DIRECTORY_PATH }}
     - run: $PACKAGE_MANAGER install --ignore-scripts

--- a/test/action.yml
+++ b/test/action.yml
@@ -4,6 +4,7 @@ runs:
     - uses: actions/download-artifact@v4
       with:
         path: ${{ env.DIRECTORY_PATH }}
+        merge-multiple: true
     - run: $PACKAGE_MANAGER install --ignore-scripts
       shell: bash
       working-directory: ${{ env.DIRECTORY_PATH }}


### PR DESCRIPTION
There is a race condition when downloading artifacts where if another job is uploading file to the same artifact as it's being downloaded, then the artifact ends up not being found, thus failing the job.

Not only has this been causing flakiness for a while now, but the latest version of the action no longer allows reusing the same name multiple times in the same workflow, presumably to address this issue.

This PR makes the name of each artifact per-job, and adds a new job to merge everything in a single artifact.

Working CI: https://github.com/DataDog/action-prebuildify/actions/runs/8693052179