### PR TITLE
Support for node 22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - id: versions
-        uses: DataDog/action-prebuildify/compute-matrix@ugaitz/support-node22
+        uses: DataDog/action-prebuildify/compute-matrix@main
         with:
           min: ${{ inputs.min-node-version }}
 
@@ -100,8 +100,8 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/docker@ugaitz/support-node22
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node22
+      - uses: DataDog/action-prebuildify/docker@main
+      - uses: DataDog/action-prebuildify/prebuild@main
         # Otherwise hangs for 6h sometimes. Remove when no longer happening.
         timeout-minutes: 10
 
@@ -118,8 +118,8 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/docker@ugaitz/support-node22
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node22
+      - uses: DataDog/action-prebuildify/docker@main
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-ia32:
     if: ${{ !contains(inputs.skip, 'linux-ia32') }}
@@ -131,7 +131,7 @@ jobs:
     steps:
       - uses: docker/setup-qemu-action@v3
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node22
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-x64:
     if: ${{ !contains(inputs.skip, 'linux-x64') }}
@@ -142,7 +142,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node22
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxmusl-x64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
@@ -157,7 +157,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl tar zstd
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node22
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
 
@@ -168,7 +168,7 @@ jobs:
       ARCH: arm64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node22
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   macos-x64:
     if: ${{ !contains(inputs.skip, 'macos-x64') }}
@@ -177,7 +177,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node22
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   windows-ia32:
     if: ${{ !contains(inputs.skip, 'windows-ia32') }}
@@ -186,7 +186,7 @@ jobs:
       ARCH: ia32
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node22
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   windows-x64:
     if: ${{ !contains(inputs.skip, 'windows-x64') }}
@@ -195,7 +195,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node22
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # Tests
 
@@ -213,7 +213,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@ugaitz/support-node22
+      - uses: DataDog/action-prebuildify/test@main
 
   linux-test:
     strategy:
@@ -226,7 +226,7 @@ jobs:
     name: linux-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@ugaitz/support-node22
+      - uses: DataDog/action-prebuildify/test@main
 
   macos-x64-test:
     strategy:
@@ -268,7 +268,7 @@ jobs:
         if: ${{ matrix.node <= '14' }}
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@ugaitz/support-node22
+      - uses: DataDog/action-prebuildify/test@main
 
   windows-test:
     strategy:
@@ -285,7 +285,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@ugaitz/support-node22
+      - uses: DataDog/action-prebuildify/test@main
 
   # Prebuilds
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - id: versions
-        uses: DataDog/action-prebuildify/compute-matrix@main
+        uses: DataDog/action-prebuildify/compute-matrix@ugaitz/support-node22
         with:
           min: ${{ inputs.min-node-version }}
 
@@ -100,8 +100,8 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/docker@main
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/docker@ugaitz/support-node22
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node22
         # Otherwise hangs for 6h sometimes. Remove when no longer happening.
         timeout-minutes: 10
 
@@ -118,8 +118,8 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/docker@main
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/docker@ugaitz/support-node22
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node22
 
   linux-ia32:
     if: ${{ !contains(inputs.skip, 'linux-ia32') }}
@@ -131,7 +131,7 @@ jobs:
     steps:
       - uses: docker/setup-qemu-action@v3
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node22
 
   linux-x64:
     if: ${{ !contains(inputs.skip, 'linux-x64') }}
@@ -142,7 +142,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node22
 
   linuxmusl-x64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
@@ -157,7 +157,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl tar zstd
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node22
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
 
@@ -168,7 +168,7 @@ jobs:
       ARCH: arm64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node22
 
   macos-x64:
     if: ${{ !contains(inputs.skip, 'macos-x64') }}
@@ -177,7 +177,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node22
 
   windows-ia32:
     if: ${{ !contains(inputs.skip, 'windows-ia32') }}
@@ -186,7 +186,7 @@ jobs:
       ARCH: ia32
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node22
 
   windows-x64:
     if: ${{ !contains(inputs.skip, 'windows-x64') }}
@@ -195,7 +195,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node22
 
   # Tests
 
@@ -213,7 +213,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@ugaitz/support-node22
 
   linux-test:
     strategy:
@@ -226,7 +226,7 @@ jobs:
     name: linux-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@ugaitz/support-node22
 
   macos-x64-test:
     strategy:
@@ -268,7 +268,7 @@ jobs:
         if: ${{ matrix.node <= '14' }}
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@ugaitz/support-node22
 
   windows-test:
     strategy:
@@ -285,7 +285,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@ugaitz/support-node22
 
   # Prebuilds
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -26,7 +26,10 @@
         ]
       }],
       ["OS == 'win'", {
-        "cflags": []
+        "cflags": [],
+        'defines': [
+            'NOMINMAX' # allow std::min/max to work
+        ],
       }]
     ]
   }]

--- a/compute-matrix/action.yml
+++ b/compute-matrix/action.yml
@@ -6,7 +6,7 @@ inputs:
     default: '12'
   max:
     description: The maximum Node.js version to include in the matrix
-    default: '21'
+    default: '22'
   step:
     description: Major version step between LTS releases
     default: '2'

--- a/compute-matrix/index.js
+++ b/compute-matrix/index.js
@@ -6,7 +6,7 @@ const { values } = parseArgs({
   args: process.argv.slice(2),
   options: {
     min: { type: 'string', default: '12' },
-    max: { type: 'string', default: '21' },
+    max: { type: 'string', default: '22' },
     step: { type: 'string', default: '2' }
   }
 })

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "node test"
   },
   "dependencies": {
-    "nan": "^2.18.0",
+    "nan": "^2.19.0",
     "node-gyp-build": "^3.9.0"
   },
   "devDependencies": {

--- a/prebuild/targets.js
+++ b/prebuild/targets.js
@@ -12,7 +12,8 @@ const nodeTargets = [
   { version: '18.0.0', abi: '108' },
   { version: '19.0.0', abi: '111' },
   { version: '20.0.0', abi: '115' },
-  { version: '21.0.0', abi: '120' }
+  { version: '21.0.0', abi: '120' },
+  { version: '22.0.0', abi: '127' }
 ]
 
 function getFilteredNodeTargets (semverConstraint) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -906,10 +906,10 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nan@^2.18.0:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.18.0.tgz#26a6faae7ffbeb293a39660e88a76b82e30b7554"
-  integrity sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==
+nan@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.19.0.tgz#bb58122ad55a6c5bc973303908d5b16cfdd5a8c0"
+  integrity sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
### What does this PR do?

- Updates nan to the latest, which works with node 22.
- Adds abi version number for node 22
- Updates params to compile for node 22
- Defines NOMINMAX for windows OS, to prevent failures: [CI with failure](https://github.com/DataDog/action-prebuildify/actions/runs/8876196031/job/24367508449?pr=44)


### Additional notes
- Here is the CI build success referencing to this branch: https://github.com/DataDog/action-prebuildify/actions/runs/8876993757/job/24369672014?pr=44
- Here is a green ci of a PR using this branch: https://github.com/DataDog/dd-native-iast-taint-tracking-js/actions/runs/8844813192?pr=103
