### PR TITLE
update prebuild action to download artifacts before building

### DIFF
--- a/prebuild/action.yml
+++ b/prebuild/action.yml
@@ -1,7 +1,7 @@
 runs:
   using: composite
   steps:
-    # In some cases (as in dd-native-appsec), it is necessary to download the artifacts previously uploaded by the parent workflow so that they can later be used in binding.gyp
+    # Make artifacts previously uploaded by the parent workflow available to binding.gyp
     - uses: actions/download-artifact@v4
     - name: Install node-gyp
       run: |

--- a/prebuild/action.yml
+++ b/prebuild/action.yml
@@ -1,6 +1,7 @@
 runs:
   using: composite
   steps:
+    # In some cases (as in dd-native-appsec), it is necessary to download the artifacts previously uploaded by the parent workflow so that they can later be used in binding.gyp
     - uses: actions/download-artifact@v4
     - name: Install node-gyp
       run: |

--- a/prebuild/action.yml
+++ b/prebuild/action.yml
@@ -1,6 +1,7 @@
 runs:
   using: composite
   steps:
+    - uses: actions/download-artifact@v4
     - name: Install node-gyp
       run: |
         yarn global add node-gyp --ignore-engines


### PR DESCRIPTION
### What does this PR do?
Allows the parent workflow to upload additional library files as artifacts so that they can later be used in `binding.gyp`.

### Additional notes

- Here is a green ci of a native-appsec PR using this branch: https://github.com/DataDog/dd-native-appsec-js/actions/runs/9018557550