### PR TITLE
Update macos because macos-11 is not supported anymore

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,7 +163,7 @@ jobs:
 
   macos-arm64:
     if: ${{ !contains(inputs.skip, 'macos-arm64') }}
-    runs-on: macos-11
+    runs-on: macos-14
     env:
       ARCH: arm64
     steps:
@@ -172,7 +172,7 @@ jobs:
 
   macos-x64:
     if: ${{ !contains(inputs.skip, 'macos-x64') }}
-    runs-on: macos-11
+    runs-on: macos-12
     env:
       ARCH: x64
     steps:
@@ -235,7 +235,7 @@ jobs:
     needs:
       - versions
       - macos-x64
-    runs-on: macos-11
+    runs-on: macos-12
     name: macos-x64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
macos-11 is not supported anymore.
source: https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/

In this PR I am updating x64 build and tests to macos-12, which uses x64 cpu and arm build to macos-14, which use arm cpu