### PR TITLE
Adding support to linuxmsl-arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,6 +159,21 @@ jobs:
       - uses: actions/checkout@v4
       - uses: DataDog/action-prebuildify/prebuild@main
 
+  linuxmusl-arm64:
+    if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
+    runs-on: ubuntu-latest
+    container:
+      # musl is statically linked so we can use more recent version of image.
+      image: node:20.0.0-alpine
+    name: linuxmusl-arm64
+    env:
+      ARCH: arm64
+      LIBC: musl
+    steps:
+      - run: apk update && apk add bash build-base git python3 curl tar zstd
+      - uses: actions/checkout@v4
+      - uses: DataDog/action-prebuildify/prebuild@main
+
   # TODO: linuxmusl-arm / linuxmusl-arm64
 
   macos-arm64:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - id: versions
-        uses: DataDog/action-prebuildify/compute-matrix@main
+        uses: DataDog/action-prebuildify/compute-matrix@ugaitz/add-linuxmusl-arm64
         with:
           min: ${{ inputs.min-node-version }}
 
@@ -100,8 +100,8 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/docker@main
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/docker@ugaitz/add-linuxmusl-arm64
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/add-linuxmusl-arm64
         # Otherwise hangs for 6h sometimes. Remove when no longer happening.
         timeout-minutes: 10
 
@@ -118,8 +118,8 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/docker@main
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/docker@ugaitz/add-linuxmusl-arm64
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/add-linuxmusl-arm64
 
   linux-ia32:
     if: ${{ !contains(inputs.skip, 'linux-ia32') }}
@@ -131,7 +131,7 @@ jobs:
     steps:
       - uses: docker/setup-qemu-action@v3
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/add-linuxmusl-arm64
 
   linux-x64:
     if: ${{ !contains(inputs.skip, 'linux-x64') }}
@@ -142,7 +142,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/add-linuxmusl-arm64
 
   linuxmusl-x64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
@@ -157,10 +157,10 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl tar zstd
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/add-linuxmusl-arm64
 
   linuxmusl-arm64:
-    if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
+    if: ${{ !contains(inputs.skip, 'linuxmusl-arm64') }}
     runs-on: ubuntu-latest
     container:
       # musl is statically linked so we can use more recent version of image.
@@ -172,7 +172,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl tar zstd
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/add-linuxmusl-arm64
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
 
@@ -183,7 +183,7 @@ jobs:
       ARCH: arm64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/add-linuxmusl-arm64
 
   macos-x64:
     if: ${{ !contains(inputs.skip, 'macos-x64') }}
@@ -192,7 +192,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/add-linuxmusl-arm64
 
   windows-ia32:
     if: ${{ !contains(inputs.skip, 'windows-ia32') }}
@@ -201,7 +201,7 @@ jobs:
       ARCH: ia32
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/add-linuxmusl-arm64
 
   windows-x64:
     if: ${{ !contains(inputs.skip, 'windows-x64') }}
@@ -210,7 +210,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/add-linuxmusl-arm64
 
   # Tests
 
@@ -228,7 +228,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@ugaitz/add-linuxmusl-arm64
 
   linux-test:
     strategy:
@@ -241,7 +241,7 @@ jobs:
     name: linux-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@ugaitz/add-linuxmusl-arm64
 
   macos-x64-test:
     strategy:
@@ -283,7 +283,7 @@ jobs:
         if: ${{ matrix.node <= '14' }}
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@ugaitz/add-linuxmusl-arm64
 
   windows-test:
     strategy:
@@ -300,7 +300,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@ugaitz/add-linuxmusl-arm64
 
   # Prebuilds
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,7 +161,7 @@ jobs:
 
   linuxmusl-arm64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-arm64') }}
-    runs-on: ubuntu-latest
+    runs-on: arm-4core-linux
     container:
       # musl is statically linked so we can use more recent version of image.
       image: node:20.0.0-alpine

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,16 +162,18 @@ jobs:
   linuxmusl-arm64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-arm64') }}
     runs-on: arm-4core-linux
-    container:
-      # musl is statically linked so we can use more recent version of image.
-      image: node:20.0.0-alpine
     name: linuxmusl-arm64
     env:
       ARCH: arm64
       LIBC: musl
+      DOCKER_BUILDER: uurien/node-to-build:20.0.0-alpine
     steps:
-      - run: apk update && apk add bash build-base git python3 curl tar zstd
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm i -g yarn
+      - uses: DataDog/action-prebuildify/docker@ugaitz/add-linuxmusl-arm64
       - uses: DataDog/action-prebuildify/prebuild@ugaitz/add-linuxmusl-arm64
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
@@ -310,6 +312,7 @@ jobs:
       - linux-arm64
       - linux-ia32
       - linuxmusl-x64
+      - linuxmusl-arm64
       - linux-x64
       - macos-arm64
       - macos-x64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - id: versions
-        uses: DataDog/action-prebuildify/compute-matrix@ugaitz/add-linuxmusl-arm64
+        uses: DataDog/action-prebuildify/compute-matrix@main
         with:
           min: ${{ inputs.min-node-version }}
 
@@ -100,8 +100,8 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/docker@ugaitz/add-linuxmusl-arm64
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/add-linuxmusl-arm64
+      - uses: DataDog/action-prebuildify/docker@main
+      - uses: DataDog/action-prebuildify/prebuild@main
         # Otherwise hangs for 6h sometimes. Remove when no longer happening.
         timeout-minutes: 10
 
@@ -118,8 +118,8 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/docker@ugaitz/add-linuxmusl-arm64
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/add-linuxmusl-arm64
+      - uses: DataDog/action-prebuildify/docker@main
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-ia32:
     if: ${{ !contains(inputs.skip, 'linux-ia32') }}
@@ -131,7 +131,7 @@ jobs:
     steps:
       - uses: docker/setup-qemu-action@v3
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/add-linuxmusl-arm64
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-x64:
     if: ${{ !contains(inputs.skip, 'linux-x64') }}
@@ -142,7 +142,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/add-linuxmusl-arm64
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxmusl-x64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
@@ -157,7 +157,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl tar zstd
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/add-linuxmusl-arm64
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxmusl-arm64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-arm64') }}
@@ -173,8 +173,8 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/docker@ugaitz/add-linuxmusl-arm64
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/add-linuxmusl-arm64
+      - uses: DataDog/action-prebuildify/docker@main
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
 
@@ -185,7 +185,7 @@ jobs:
       ARCH: arm64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/add-linuxmusl-arm64
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   macos-x64:
     if: ${{ !contains(inputs.skip, 'macos-x64') }}
@@ -194,7 +194,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/add-linuxmusl-arm64
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   windows-ia32:
     if: ${{ !contains(inputs.skip, 'windows-ia32') }}
@@ -203,7 +203,7 @@ jobs:
       ARCH: ia32
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/add-linuxmusl-arm64
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   windows-x64:
     if: ${{ !contains(inputs.skip, 'windows-x64') }}
@@ -212,7 +212,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/add-linuxmusl-arm64
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # Tests
 
@@ -230,7 +230,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@ugaitz/add-linuxmusl-arm64
+      - uses: DataDog/action-prebuildify/test@main
 
   linux-test:
     strategy:
@@ -243,7 +243,7 @@ jobs:
     name: linux-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@ugaitz/add-linuxmusl-arm64
+      - uses: DataDog/action-prebuildify/test@main
 
   macos-x64-test:
     strategy:
@@ -285,7 +285,7 @@ jobs:
         if: ${{ matrix.node <= '14' }}
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@ugaitz/add-linuxmusl-arm64
+      - uses: DataDog/action-prebuildify/test@main
 
   windows-test:
     strategy:
@@ -302,7 +302,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@ugaitz/add-linuxmusl-arm64
+      - uses: DataDog/action-prebuildify/test@main
 
   # Prebuilds
 

--- a/prebuild/action.yml
+++ b/prebuild/action.yml
@@ -51,6 +51,7 @@ runs:
           -e DIRECTORY_PATH="$DIRECTORY_PATH" \
           -e NODE_VERSIONS="$NODE_VERSIONS" \
           -e NODE_HEADERS_DIRECTORY="/usr/node_headers" \
+          -e LIBC="$LIBC" \
           -w /usr/action \
           $DOCKER_BUILDER \
           /bin/bash -c 'yarn && cd /usr/workspace && yarn exec node /usr/action'

--- a/prebuild/index.js
+++ b/prebuild/index.js
@@ -90,7 +90,7 @@ function prebuildTarget (arch, target) {
     cmd = `cd ${DIRECTORY_PATH} && ${napiBuildCommand} --release`
   } else if (NEON === 'true') {
     installRust()
-    console.log('rust installed')
+
     cmd = `cd ${DIRECTORY_PATH} && npm run build-release`
   } else {
     cmd = [
@@ -110,15 +110,12 @@ function prebuildTarget (arch, target) {
     ].join(' ')
   }
 
-  console.log('execSync: ', cmd)
   execSync(cmd, { stdio, shell })
-  console.log('executed', cmd)
 
   if (NAPI_RS === 'true') {
     const output = `${DIRECTORY_PATH}/prebuilds/${platform}${libc}-${arch}/node-napi.node`
     fs.copyFileSync(`${DIRECTORY_PATH}/${TARGET_NAME}.node`, output)
   } else if (NEON === 'true') {
-    console.log('copyy')
     const output = `${DIRECTORY_PATH}/prebuilds/${platform}${libc}-${arch}/node-napi.node`
     fs.copyFileSync(`${DIRECTORY_PATH}/build/Release/${TARGET_NAME}.node`, output)
   } else {
@@ -130,9 +127,7 @@ function prebuildTarget (arch, target) {
 function installRust () {
   const target = napiTargets[`${platform}${libc}-${arch}`]
 
-  const cargoPath = process.env.HOME + path.sep + '.cargo' + path.sep + 'bin'
-
-  process.env.PATH += path.delimiter + cargoPath
+  process.env.PATH += path.delimiter + process.env.HOME + path.sep + '.cargo' + path.sep + 'bin'
   process.env.CARGO_BUILD_TARGET = target
 
   if (platform === 'linux' && libc === 'musl') {
@@ -148,6 +143,4 @@ function installRust () {
 
   execSync('rustup toolchain install nightly --no-self-update', { stdio, shell })
   execSync('rustup component add rust-src --toolchain nightly', { stdio, shell })
-  console.log(`${ cargoPath + path.sep }cargo --version`)
-  execSync(`${ cargoPath + path.sep }cargo --version`, { stdio, shell })
 }

--- a/prebuild/index.js
+++ b/prebuild/index.js
@@ -90,7 +90,7 @@ function prebuildTarget (arch, target) {
     cmd = `cd ${DIRECTORY_PATH} && ${napiBuildCommand} --release`
   } else if (NEON === 'true') {
     installRust()
-
+    console.log('rust installed')
     cmd = `cd ${DIRECTORY_PATH} && npm run build-release`
   } else {
     cmd = [
@@ -110,12 +110,15 @@ function prebuildTarget (arch, target) {
     ].join(' ')
   }
 
+  console.log('execSync: ', cmd)
   execSync(cmd, { stdio, shell })
+  console.log('executed', cmd)
 
   if (NAPI_RS === 'true') {
     const output = `${DIRECTORY_PATH}/prebuilds/${platform}${libc}-${arch}/node-napi.node`
     fs.copyFileSync(`${DIRECTORY_PATH}/${TARGET_NAME}.node`, output)
   } else if (NEON === 'true') {
+    console.log('copyy')
     const output = `${DIRECTORY_PATH}/prebuilds/${platform}${libc}-${arch}/node-napi.node`
     fs.copyFileSync(`${DIRECTORY_PATH}/build/Release/${TARGET_NAME}.node`, output)
   } else {
@@ -127,7 +130,9 @@ function prebuildTarget (arch, target) {
 function installRust () {
   const target = napiTargets[`${platform}${libc}-${arch}`]
 
-  process.env.PATH += path.delimiter + process.env.HOME + path.sep + '.cargo' + path.sep + 'bin'
+  const cargoPath = process.env.HOME + path.sep + '.cargo' + path.sep + 'bin'
+
+  process.env.PATH += path.delimiter + cargoPath
   process.env.CARGO_BUILD_TARGET = target
 
   if (platform === 'linux' && libc === 'musl') {
@@ -143,4 +148,6 @@ function installRust () {
 
   execSync('rustup toolchain install nightly --no-self-update', { stdio, shell })
   execSync('rustup component add rust-src --toolchain nightly', { stdio, shell })
+  console.log(`${ cargoPath + path.sep }cargo --version`)
+  execSync(`${ cargoPath + path.sep }cargo --version`, { stdio, shell })
 }


### PR DESCRIPTION
This PR adds support to linuxmusl-arm64.

CI run build: https://github.com/DataDog/action-prebuildify/actions/runs/10073712817/job/27848332288?pr=48
CI run build (NEON): https://github.com/DataDog/action-prebuildify/actions/runs/10073711872/job/27848327566?pr=48
