### PR TITLE
allow toolchain version pinning from callers and pin test version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
           node-version: 18
       - run: npm i -g yarn
       - uses: DataDog/action-prebuildify/docker@main
-      - uses: DataDog/action-prebuildify/prebuild@nightly-2024-08-01
+      - uses: DataDog/action-prebuildify/prebuild@main
         # Otherwise hangs for 6h sometimes. Remove when no longer happening.
         timeout-minutes: 10
 
@@ -119,7 +119,7 @@ jobs:
           node-version: 18
       - run: npm i -g yarn
       - uses: DataDog/action-prebuildify/docker@main
-      - uses: DataDog/action-prebuildify/prebuild@nightly-2024-08-01
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-ia32:
     if: ${{ !contains(inputs.skip, 'linux-ia32') }}
@@ -131,7 +131,7 @@ jobs:
     steps:
       - uses: docker/setup-qemu-action@v3
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@nightly-2024-08-01
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-x64:
     if: ${{ !contains(inputs.skip, 'linux-x64') }}
@@ -142,7 +142,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@nightly-2024-08-01
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxmusl-x64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
@@ -157,7 +157,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl tar zstd
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@nightly-2024-08-01
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxmusl-arm64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-arm64') }}
@@ -174,7 +174,7 @@ jobs:
           node-version: 18
       - run: npm i -g yarn
       - uses: DataDog/action-prebuildify/docker@main
-      - uses: DataDog/action-prebuildify/prebuild@nightly-2024-08-01
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
 
@@ -185,7 +185,7 @@ jobs:
       ARCH: arm64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@nightly-2024-08-01
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   macos-x64:
     if: ${{ !contains(inputs.skip, 'macos-x64') }}
@@ -194,7 +194,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@nightly-2024-08-01
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   windows-ia32:
     if: ${{ !contains(inputs.skip, 'windows-ia32') }}
@@ -203,7 +203,7 @@ jobs:
       ARCH: ia32
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@nightly-2024-08-01
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   windows-x64:
     if: ${{ !contains(inputs.skip, 'windows-x64') }}
@@ -212,7 +212,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@nightly-2024-08-01
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # Tests
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
           node-version: 18
       - run: npm i -g yarn
       - uses: DataDog/action-prebuildify/docker@main
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@nightly-2024-08-01
         # Otherwise hangs for 6h sometimes. Remove when no longer happening.
         timeout-minutes: 10
 
@@ -119,7 +119,7 @@ jobs:
           node-version: 18
       - run: npm i -g yarn
       - uses: DataDog/action-prebuildify/docker@main
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@nightly-2024-08-01
 
   linux-ia32:
     if: ${{ !contains(inputs.skip, 'linux-ia32') }}
@@ -131,7 +131,7 @@ jobs:
     steps:
       - uses: docker/setup-qemu-action@v3
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@nightly-2024-08-01
 
   linux-x64:
     if: ${{ !contains(inputs.skip, 'linux-x64') }}
@@ -142,7 +142,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@nightly-2024-08-01
 
   linuxmusl-x64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
@@ -157,7 +157,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl tar zstd
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@nightly-2024-08-01
 
   linuxmusl-arm64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-arm64') }}
@@ -174,7 +174,7 @@ jobs:
           node-version: 18
       - run: npm i -g yarn
       - uses: DataDog/action-prebuildify/docker@main
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@nightly-2024-08-01
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
 
@@ -185,7 +185,7 @@ jobs:
       ARCH: arm64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@nightly-2024-08-01
 
   macos-x64:
     if: ${{ !contains(inputs.skip, 'macos-x64') }}
@@ -194,7 +194,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@nightly-2024-08-01
 
   windows-ia32:
     if: ${{ !contains(inputs.skip, 'windows-ia32') }}
@@ -203,7 +203,7 @@ jobs:
       ARCH: ia32
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@nightly-2024-08-01
 
   windows-x64:
     if: ${{ !contains(inputs.skip, 'windows-x64') }}
@@ -212,7 +212,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@nightly-2024-08-01
 
   # Tests
 

--- a/prebuild/index.js
+++ b/prebuild/index.js
@@ -139,7 +139,7 @@ function installRust () {
   // installed, for example on GitHub Actions Windows runners.
   execSync([
     "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs",
-    `sh -s -- -y --verbose --default-host ${target}`
+    `sh -s -- -y --verbose --no-update-default-toolchain --default-host ${target}`
   ].join(' | '), { cwd, stdio, shell })
 
   execSync('rustup component add rust-src', { cwd, stdio, shell })

--- a/prebuild/index.js
+++ b/prebuild/index.js
@@ -141,6 +141,6 @@ function installRust () {
     `sh -s -- -y --verbose --default-host ${target}`
   ].join(' | '), { stdio, shell })
 
-  execSync('rustup toolchain install nightly --no-self-update', { stdio, shell })
-  execSync('rustup component add rust-src --toolchain nightly', { stdio, shell })
+  execSync('rustup toolchain install nightly-2024-08-01 --no-self-update', { stdio, shell })
+  execSync('rustup component add rust-src --toolchain nightly-2024-08-01', { stdio, shell })
 }

--- a/prebuild/index.js
+++ b/prebuild/index.js
@@ -141,6 +141,5 @@ function installRust () {
     `sh -s -- -y --verbose --default-host ${target}`
   ].join(' | '), { stdio, shell })
 
-  execSync('rustup toolchain install nightly-2024-08-01 --no-self-update', { stdio, shell })
-  execSync('rustup component add rust-src --toolchain nightly-2024-08-01', { stdio, shell })
+  execSync(`cd ${DIRECTORY_PATH} && rustup component add rust-src`, { stdio, shell })
 }

--- a/prebuild/index.js
+++ b/prebuild/index.js
@@ -12,6 +12,7 @@ const arch = process.env.ARCH || os.arch()
 const libc = process.env.LIBC || ''
 const stdio = [0, 1, 2]
 const shell = process.env.SHELL
+const cwd = path.join(process.cwd(), process.env.DIRECTORY_PATH)
 
 const {
   NAPI = 'false',
@@ -51,7 +52,7 @@ function prebuildify () {
   fs.mkdirSync(`${DIRECTORY_PATH}/prebuilds/${platform}${libc}-${arch}`, { recursive: true })
 
   if (PREBUILD) {
-    execSync(PREBUILD, { stdio, shell })
+    execSync(PREBUILD, { cwd, stdio, shell })
   }
 
   if (NAPI === 'true') {
@@ -63,7 +64,7 @@ function prebuildify () {
   }
 
   if (POSTBUILD) {
-    execSync(POSTBUILD, { stdio, shell })
+    execSync(POSTBUILD, { cwd, stdio, shell })
   }
 }
 
@@ -87,11 +88,11 @@ function prebuildTarget (arch, target) {
       napiBuildCommand = `${path.join(__dirname, 'node_modules', '.bin', 'napi')} build`
     }
 
-    cmd = `cd ${DIRECTORY_PATH} && ${napiBuildCommand} --release`
+    cmd = `${napiBuildCommand} --release`
   } else if (NEON === 'true') {
     installRust()
 
-    cmd = `cd ${DIRECTORY_PATH} && npm run build-release`
+    cmd = 'npm run build-release'
   } else {
     cmd = [
       'node-gyp rebuild',
@@ -110,7 +111,7 @@ function prebuildTarget (arch, target) {
     ].join(' ')
   }
 
-  execSync(cmd, { stdio, shell })
+  execSync(cmd, { cwd, stdio, shell })
 
   if (NAPI_RS === 'true') {
     const output = `${DIRECTORY_PATH}/prebuilds/${platform}${libc}-${arch}/node-napi.node`
@@ -139,7 +140,7 @@ function installRust () {
   execSync([
     "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs",
     `sh -s -- -y --verbose --default-host ${target}`
-  ].join(' | '), { stdio, shell })
+  ].join(' | '), { cwd, stdio, shell })
 
-  execSync(`cd ${DIRECTORY_PATH} && rustup component add rust-src`, { stdio, shell })
+  execSync('rustup component add rust-src', { cwd, stdio, shell })
 }

--- a/test/neon/package.json
+++ b/test/neon/package.json
@@ -4,7 +4,7 @@
   "description": "Neon test application.",
   "main": "index.node",
   "scripts": {
-    "build": "cargo-cp-artifact -nc build/Release/test.node -- cargo +nightly build -Z build-std=std,panic_abort --message-format=json-render-diagnostics",
+    "build": "cargo-cp-artifact -nc build/Release/test.node -- cargo build -Z build-std=std,panic_abort --message-format=json-render-diagnostics",
     "build-debug": "npm run build --",
     "build-release": "npm run build -- --release",
     "test": "node test"

--- a/test/neon/rust-toolchain.toml
+++ b/test/neon/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2024-08-01"

--- a/test/neon/rust-toolchain.toml
+++ b/test/neon/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2024-08-01"
+channel = "nightly-2024-07-01"


### PR DESCRIPTION
This PR switches to `rust-toolchain.toml` to leave the decision of which toolchain to use to the caller. It also fixes the toolchain for the tests to a specific date to avoid nightly Rust builds starting to break our scheduled CI run on any given day. Ideally we'd be using `stable` for the tests, but it doesn't support building `rust-src` so we have to default to a nightly.

Working CI: https://github.com/DataDog/action-prebuildify/actions/runs/10295499138