### PR TITLE
add new rust mode that copies all files untouched

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
           node-version: 18
       - run: npm i -g yarn
       - uses: DataDog/action-prebuildify/docker@main
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@rochdev/targets
         # Otherwise hangs for 6h sometimes. Remove when no longer happening.
         timeout-minutes: 10
 
@@ -119,7 +119,7 @@ jobs:
           node-version: 18
       - run: npm i -g yarn
       - uses: DataDog/action-prebuildify/docker@main
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@rochdev/targets
 
   linux-ia32:
     if: ${{ !contains(inputs.skip, 'linux-ia32') }}
@@ -131,7 +131,7 @@ jobs:
     steps:
       - uses: docker/setup-qemu-action@v3
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@rochdev/targets
 
   linux-x64:
     if: ${{ !contains(inputs.skip, 'linux-x64') }}
@@ -142,7 +142,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@rochdev/targets
 
   linuxmusl-x64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
@@ -157,7 +157,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl tar zstd
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@rochdev/targets
 
   linuxmusl-arm64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-arm64') }}
@@ -174,7 +174,7 @@ jobs:
           node-version: 18
       - run: npm i -g yarn
       - uses: DataDog/action-prebuildify/docker@main
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@rochdev/targets
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
 
@@ -185,7 +185,7 @@ jobs:
       ARCH: arm64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@rochdev/targets
 
   macos-x64:
     if: ${{ !contains(inputs.skip, 'macos-x64') }}
@@ -194,7 +194,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@rochdev/targets
 
   windows-ia32:
     if: ${{ !contains(inputs.skip, 'windows-ia32') }}
@@ -203,7 +203,7 @@ jobs:
       ARCH: ia32
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@rochdev/targets
 
   windows-x64:
     if: ${{ !contains(inputs.skip, 'windows-x64') }}
@@ -212,7 +212,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@rochdev/targets
 
   # Tests
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,11 @@ on:
         default: false
         required: false
         type: boolean
+      rust:
+        description: Whether or not this build is for a Rust project.
+        default: false
+        required: false
+        type: boolean
       directory-path:
         description: The path to the directory containing your build files, relative to the repo root.
         default: '.'
@@ -72,6 +77,7 @@ env:
   TARGET_NAME: ${{ inputs.target-name }}
   NAPI_RS: ${{ inputs.napi-rs }}
   NEON: ${{ inputs.neon }}
+  RUST: ${{ inputs.rust }}
   DIRECTORY_PATH: ${{ inputs.directory-path }}
   NODE_VERSIONS: '>=${{ inputs.min-node-version }}'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
           node-version: 18
       - run: npm i -g yarn
       - uses: DataDog/action-prebuildify/docker@main
-      - uses: DataDog/action-prebuildify/prebuild@rochdev/targets
+      - uses: DataDog/action-prebuildify/prebuild@main
         # Otherwise hangs for 6h sometimes. Remove when no longer happening.
         timeout-minutes: 10
 
@@ -125,7 +125,7 @@ jobs:
           node-version: 18
       - run: npm i -g yarn
       - uses: DataDog/action-prebuildify/docker@main
-      - uses: DataDog/action-prebuildify/prebuild@rochdev/targets
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-ia32:
     if: ${{ !contains(inputs.skip, 'linux-ia32') }}
@@ -137,7 +137,7 @@ jobs:
     steps:
       - uses: docker/setup-qemu-action@v3
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@rochdev/targets
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linux-x64:
     if: ${{ !contains(inputs.skip, 'linux-x64') }}
@@ -148,7 +148,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@rochdev/targets
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxmusl-x64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-x64') }}
@@ -163,7 +163,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl tar zstd
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@rochdev/targets
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxmusl-arm64:
     if: ${{ !contains(inputs.skip, 'linuxmusl-arm64') }}
@@ -180,7 +180,7 @@ jobs:
           node-version: 18
       - run: npm i -g yarn
       - uses: DataDog/action-prebuildify/docker@main
-      - uses: DataDog/action-prebuildify/prebuild@rochdev/targets
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # TODO: linuxmusl-arm / linuxmusl-arm64
 
@@ -191,7 +191,7 @@ jobs:
       ARCH: arm64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@rochdev/targets
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   macos-x64:
     if: ${{ !contains(inputs.skip, 'macos-x64') }}
@@ -200,7 +200,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@rochdev/targets
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   windows-ia32:
     if: ${{ !contains(inputs.skip, 'windows-ia32') }}
@@ -209,7 +209,7 @@ jobs:
       ARCH: ia32
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@rochdev/targets
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   windows-x64:
     if: ${{ !contains(inputs.skip, 'windows-x64') }}
@@ -218,7 +218,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@rochdev/targets
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # Tests
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ jobs:
       package-manager: 'npm' # npm or yarn
       postbuild: '' # command to run after prebuilds have been generated
       prebuild: '' # command to run before prebuilds are generated
+      rust: false # Whether or not this build is for a Rust project.
       skip: '' # list of jobs to skip, for example when a platform is not supported
       target-name: 'addon' # target name in binding.gyp (or napi.name in package.json for napi-rs projects)
 ```

--- a/prebuild/action.yml
+++ b/prebuild/action.yml
@@ -48,6 +48,7 @@ runs:
           -e TARGET_NAME="$TARGET_NAME" \
           -e NAPI_RS="$NAPI_RS" \
           -e NEON="$NEON" \
+          -e RUST="$RUST" \
           -e DIRECTORY_PATH="$DIRECTORY_PATH" \
           -e NODE_VERSIONS="$NODE_VERSIONS" \
           -e NODE_HEADERS_DIRECTORY="/usr/node_headers" \

--- a/prebuild/index.js
+++ b/prebuild/index.js
@@ -113,15 +113,19 @@ function prebuildTarget (arch, target) {
 
   execSync(cmd, { cwd, stdio, shell })
 
-  if (NAPI_RS === 'true') {
-    const output = `${DIRECTORY_PATH}/prebuilds/${platform}${libc}-${arch}/${TARGET_NAME}-napi.node`
-    fs.copyFileSync(`${DIRECTORY_PATH}/${TARGET_NAME}.node`, output)
-  } else if (NEON === 'true') {
-    const output = `${DIRECTORY_PATH}/prebuilds/${platform}${libc}-${arch}/${TARGET_NAME}-napi.node`
-    fs.copyFileSync(`${DIRECTORY_PATH}/build/Release/${TARGET_NAME}.node`, output)
-  } else {
-    const output = `${DIRECTORY_PATH}/prebuilds/${platform}${libc}-${arch}/${TARGET_NAME}-${target.abi}.node`
-    fs.copyFileSync(`${DIRECTORY_PATH}/build/Release/${TARGET_NAME}.node`, output)
+  const names = TARGET_NAME.split(',')
+
+  for (const name of names) {
+    if (NAPI_RS === 'true') {
+      const output = `${DIRECTORY_PATH}/prebuilds/${platform}${libc}-${arch}/${name}-napi.node`
+      fs.copyFileSync(`${DIRECTORY_PATH}/${name}.node`, output)
+    } else if (NEON === 'true') {
+      const output = `${DIRECTORY_PATH}/prebuilds/${platform}${libc}-${arch}/${name}-napi.node`
+      fs.copyFileSync(`${DIRECTORY_PATH}/build/Release/${name}.node`, output)
+    } else {
+      const output = `${DIRECTORY_PATH}/prebuilds/${platform}${libc}-${arch}/${name}-${target.abi}.node`
+      fs.copyFileSync(`${DIRECTORY_PATH}/build/Release/${name}.node`, output)
+    }
   }
 }
 

--- a/prebuild/index.js
+++ b/prebuild/index.js
@@ -114,13 +114,13 @@ function prebuildTarget (arch, target) {
   execSync(cmd, { cwd, stdio, shell })
 
   if (NAPI_RS === 'true') {
-    const output = `${DIRECTORY_PATH}/prebuilds/${platform}${libc}-${arch}/node-napi.node`
+    const output = `${DIRECTORY_PATH}/prebuilds/${platform}${libc}-${arch}/${TARGET_NAME}-napi.node`
     fs.copyFileSync(`${DIRECTORY_PATH}/${TARGET_NAME}.node`, output)
   } else if (NEON === 'true') {
-    const output = `${DIRECTORY_PATH}/prebuilds/${platform}${libc}-${arch}/node-napi.node`
+    const output = `${DIRECTORY_PATH}/prebuilds/${platform}${libc}-${arch}/${TARGET_NAME}-napi.node`
     fs.copyFileSync(`${DIRECTORY_PATH}/build/Release/${TARGET_NAME}.node`, output)
   } else {
-    const output = `${DIRECTORY_PATH}/prebuilds/${platform}${libc}-${arch}/node-${target.abi}.node`
+    const output = `${DIRECTORY_PATH}/prebuilds/${platform}${libc}-${arch}/${TARGET_NAME}-${target.abi}.node`
     fs.copyFileSync(`${DIRECTORY_PATH}/build/Release/${TARGET_NAME}.node`, output)
   }
 }


### PR DESCRIPTION
The previous approach doesn't allow multiple files to be prebuilt. This can be problematic for Rust projects since Cargo supports multiple members and each member can output multiple libraries and binaries. With this change, for Rust projects the entire `build/Release` folder will be copied for each prebuild. This has the limitation that node-gyp-build no longer understands the output, but for now it's an acceptable limitation as it's not very difficult to write a loader that detects the current platform, and a new module can be created later to make that logic reusable.

Working CI:
- https://github.com/DataDog/action-prebuildify/actions/runs/10333444419
- https://github.com/DataDog/action-prebuildify/actions/runs/10333444421