### PR TITLE
remove qemu entirely and add linux arm tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,6 @@ jobs:
       ARCH: ia32
       DOCKER_BUILDER: rochdev/holy-node-box:12-i386
     steps:
-      - uses: docker/setup-qemu-action@v3
       - uses: actions/checkout@v4
       - uses: DataDog/action-prebuildify/prebuild@main
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,8 +108,6 @@ jobs:
           node-version: 18
       - run: npm i -g yarn
       - uses: DataDog/action-prebuildify/prebuild@main
-        # Otherwise hangs for 6h sometimes. Remove when no longer happening.
-        timeout-minutes: 10
 
   linux-arm64:
     if: ${{ !contains(inputs.skip, 'linux-arm64') }}
@@ -180,7 +178,7 @@ jobs:
       - run: npm i -g yarn
       - uses: DataDog/action-prebuildify/prebuild@main
 
-  # TODO: linuxmusl-arm / linuxmusl-arm64
+  # TODO: linuxmusl-arm
 
   macos-arm64:
     if: ${{ !contains(inputs.skip, 'macos-arm64') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,14 +221,13 @@ jobs:
     strategy:
       matrix:
         node: ${{ fromJson(needs.versions.outputs.versions) }}
-        arch: [x64, arm64]
     needs:
       - versions
       - prebuilds
-    runs-on: ${{ matrix.arch == 'arm64' && 'arm-4core-linux-arm-limited' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     container:
       image: node:${{ matrix.node }}-alpine
-    name: alpine-test-${{ matrix.arch }}-${{ matrix.node }}
+    name: alpine-test-${{ matrix.node }}
     steps:
       - run: apk update && apk add bash build-base git python3 curl
       - uses: actions/checkout@v4
@@ -243,7 +242,7 @@ jobs:
       - versions
       - prebuilds
     runs-on: ${{ matrix.arch == 'arm64' && 'arm-4core-linux-arm-limited' || 'ubuntu-latest' }}
-    name: linux-test-${{ matrix.arch }}-${{ matrix.node }}
+    name: linux-test-${{ matrix.node }}-${{ matrix.arch }}
     steps:
       - uses: actions/checkout@v4
       - uses: DataDog/action-prebuildify/test@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,7 +227,7 @@ jobs:
       - prebuilds
     runs-on: ${{ matrix.arch == 'arm64' && 'arm-4core-linux-arm-limited' || 'ubuntu-latest' }}
     container:
-      image: ${{ matrix.node }}-alpine
+      image: node:${{ matrix.node }}-alpine
     name: alpine-test-${{ matrix.arch }}-${{ matrix.node }}
     steps:
       - run: apk update && apk add bash build-base git python3 curl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,13 +224,14 @@ jobs:
     strategy:
       matrix:
         node: ${{ fromJson(needs.versions.outputs.versions) }}
+        arch: [x64, arm64]
     needs:
       - versions
       - prebuilds
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.arch == 'arm64' && 'arm-4core-linux-arm-limited' || 'ubuntu-latest' }}
     container:
-      image: node:${{ matrix.node }}-alpine
-    name: alpine-test-${{ matrix.node }}
+      image: ${{ matrix.node }}-alpine
+    name: alpine-test-${{ matrix.arch }}-${{ matrix.node }}
     steps:
       - run: apk update && apk add bash build-base git python3 curl
       - uses: actions/checkout@v4
@@ -240,11 +241,12 @@ jobs:
     strategy:
       matrix:
         node: ${{ fromJson(needs.versions.outputs.versions) }}
+        arch: [x64, arm64]
     needs:
       - versions
       - prebuilds
-    runs-on: ubuntu-latest
-    name: linux-test-${{ matrix.node }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'arm-4core-linux-arm-limited' || 'ubuntu-latest' }}
+    name: linux-test-${{ matrix.arch }}-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
       - uses: DataDog/action-prebuildify/test@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,6 @@ jobs:
         with:
           min: ${{ inputs.min-node-version }}
 
-  # TODO: Add tests when out of beta and we have more ARM runners available.
   linux-arm:
     if: ${{ !contains(inputs.skip, 'linux-arm') }}
     runs-on: arm-4core-linux-arm-limited


### PR DESCRIPTION
This PR adds tests for Linux ARM and removes QEmu completely. At this point QEmu was only used for Linux ia32 but it's not needed because `process.arch` returns the architecture that Node was built on and not the one from the CPU, so it will build the right target even on an x64 CPU. There was also a timeout that was added because of QEmu on a job that no longer uses it, so I removed that as well at the same time.