### PR TITLE
add support for testing executable binaries

### DIFF
--- a/test/action.yml
+++ b/test/action.yml
@@ -4,6 +4,9 @@ runs:
     - uses: actions/download-artifact@v4
       with:
         path: ${{ env.DIRECTORY_PATH }}
+    - run: chmod -R +x ./prebuilds
+      shell: bash
+      working-directory: ${{ env.DIRECTORY_PATH }}
     - run: $PACKAGE_MANAGER install --ignore-scripts
       shell: bash
       working-directory: ${{ env.DIRECTORY_PATH }}


### PR DESCRIPTION
Testing executable binaries requires them to be executable. Since artifacts lose their permissions, this cannot be done at the source and needs to be done right in the test instead.

Working CI:

https://github.com/DataDog/action-prebuildify/actions/runs/10910511026
https://github.com/DataDog/action-prebuildify/actions/runs/10910511017