### PR TITLE
make libc target explicit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,7 +275,7 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   linux-arm64-test:
-    if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linux-arm64') }}
+    if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
     strategy:
       matrix:
         node: ${{ fromJson(needs.versions.outputs.versions) }}
@@ -290,7 +290,7 @@ jobs:
       - uses: DataDog/action-prebuildify/test@main
 
   linux-x64-test:
-    if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linux-x64') }}
+    if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
     strategy:
       matrix:
         node: ${{ fromJson(needs.versions.outputs.versions) }}
@@ -371,12 +371,12 @@ jobs:
 
   prebuilds:
     needs:
-      - linux-arm
-      - linux-arm64
-      - linux-ia32
+      - linuxglibc-arm
+      - linuxglibc-arm64
+      - linuxglibc-ia32
       - linuxmusl-x64
       - linuxmusl-arm64
-      - linux-x64
+      - linuxglibc-x64
       - darwin-arm64
       - darwin-x64
       - win32-ia32

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
       - platforms
     env:
       ARCH: arm
-      LIBC: libc
+      LIBC: glibc
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm32v7
     steps:
       - uses: actions/checkout@v4
@@ -135,7 +135,7 @@ jobs:
       - platforms
     env:
       ARCH: arm64
-      LIBC: libc
+      LIBC: glibc
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8
     steps:
       - uses: actions/checkout@v4
@@ -153,7 +153,7 @@ jobs:
       - platforms
     env:
       ARCH: ia32
-      LIBC: libc
+      LIBC: glibc
       DOCKER_BUILDER: rochdev/holy-node-box:12-i386
     steps:
       - uses: actions/checkout@v4
@@ -167,7 +167,7 @@ jobs:
       - platforms
     env:
       ARCH: x64
-      LIBC: libc
+      LIBC: glibc
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,6 +117,7 @@ jobs:
       - platforms
     env:
       ARCH: arm
+      LIBC: libc
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm32v7
     steps:
       - uses: actions/checkout@v4
@@ -134,6 +135,7 @@ jobs:
       - platforms
     env:
       ARCH: arm64
+      LIBC: libc
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8
     steps:
       - uses: actions/checkout@v4
@@ -151,6 +153,7 @@ jobs:
       - platforms
     env:
       ARCH: ia32
+      LIBC: libc
       DOCKER_BUILDER: rochdev/holy-node-box:12-i386
     steps:
       - uses: actions/checkout@v4
@@ -164,6 +167,7 @@ jobs:
       - platforms
     env:
       ARCH: x64
+      LIBC: libc
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,10 +109,10 @@ jobs:
           skip: ${{ inputs.skip }}
           only: ${{ inputs.only }}
 
-  linux-arm:
-    if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linux-arm') }}
+  linuxglibc-arm:
+    if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm') }}
     runs-on: arm-4core-linux-arm-limited
-    name: linux-arm
+    name: linuxglibc-arm
     needs:
       - platforms
     env:
@@ -127,10 +127,10 @@ jobs:
       - run: npm i -g yarn
       - uses: DataDog/action-prebuildify/prebuild@main
 
-  linux-arm64:
-    if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linux-arm64') }}
+  linuxglibc-arm64:
+    if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
     runs-on: arm-4core-linux-arm-limited
-    name: linux-arm64
+    name: linuxglibc-arm64
     needs:
       - platforms
     env:
@@ -145,10 +145,10 @@ jobs:
       - run: npm i -g yarn
       - uses: DataDog/action-prebuildify/prebuild@main
 
-  linux-ia32:
-    if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linux-ia32') }}
+  linuxglibc-ia32:
+    if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-ia32') }}
     runs-on: ubuntu-latest
-    name: linux-ia32
+    name: linuxglibc-ia32
     needs:
       - platforms
     env:
@@ -159,10 +159,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: DataDog/action-prebuildify/prebuild@main
 
-  linux-x64:
-    if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linux-x64') }}
+  linuxglibc-x64:
+    if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
     runs-on: ubuntu-latest
-    name: linux-x64
+    name: linuxglibc-x64
     needs:
       - platforms
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - id: versions
-        uses: DataDog/action-prebuildify/compute-matrix@rochdev/explicit-libc
+        uses: DataDog/action-prebuildify/compute-matrix@main
         with:
           min: ${{ inputs.min-node-version }}
 
@@ -104,7 +104,7 @@ jobs:
       platforms: ${{ steps.platforms.outputs.platforms }}
     steps:
       - id: platforms
-        uses: DataDog/action-prebuildify/platforms@rochdev/explicit-libc
+        uses: DataDog/action-prebuildify/platforms@main
         with:
           skip: ${{ inputs.skip }}
           only: ${{ inputs.only }}
@@ -125,7 +125,7 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/prebuild@rochdev/explicit-libc
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxglibc-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -143,7 +143,7 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/prebuild@rochdev/explicit-libc
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxglibc-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-ia32') }}
@@ -157,7 +157,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-i386
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@rochdev/explicit-libc
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxglibc-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -171,7 +171,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@rochdev/explicit-libc
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxmusl-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-x64') }}
@@ -188,7 +188,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl tar zstd
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@rochdev/explicit-libc
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxmusl-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-arm64') }}
@@ -206,7 +206,7 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/prebuild@rochdev/explicit-libc
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # TODO: linuxmusl-arm
 
@@ -219,7 +219,7 @@ jobs:
       ARCH: arm64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@rochdev/explicit-libc
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   darwin-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'darwin-x64') }}
@@ -230,7 +230,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@rochdev/explicit-libc
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   win32-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-ia32') }}
@@ -241,7 +241,7 @@ jobs:
       ARCH: ia32
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@rochdev/explicit-libc
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   win32-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-x64') }}
@@ -252,7 +252,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@rochdev/explicit-libc
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # Tests
 
@@ -272,7 +272,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@rochdev/explicit-libc
+      - uses: DataDog/action-prebuildify/test@main
 
   linux-arm64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -287,7 +287,7 @@ jobs:
     name: linux-arm64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@rochdev/explicit-libc
+      - uses: DataDog/action-prebuildify/test@main
 
   linux-x64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -302,7 +302,7 @@ jobs:
     name: linux-x64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@rochdev/explicit-libc
+      - uses: DataDog/action-prebuildify/test@main
 
   darwin-x64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'darwin-x64') }}
@@ -346,7 +346,7 @@ jobs:
         if: ${{ matrix.node <= '14' }}
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@rochdev/explicit-libc
+      - uses: DataDog/action-prebuildify/test@main
 
   win32-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'win32-x64') }}
@@ -365,7 +365,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@rochdev/explicit-libc
+      - uses: DataDog/action-prebuildify/test@main
 
   # Prebuilds
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - id: versions
-        uses: DataDog/action-prebuildify/compute-matrix@main
+        uses: DataDog/action-prebuildify/compute-matrix@rochdev/explicit-libc
         with:
           min: ${{ inputs.min-node-version }}
 
@@ -104,7 +104,7 @@ jobs:
       platforms: ${{ steps.platforms.outputs.platforms }}
     steps:
       - id: platforms
-        uses: DataDog/action-prebuildify/platforms@main
+        uses: DataDog/action-prebuildify/platforms@rochdev/explicit-libc
         with:
           skip: ${{ inputs.skip }}
           only: ${{ inputs.only }}
@@ -125,7 +125,7 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@rochdev/explicit-libc
 
   linuxglibc-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -143,7 +143,7 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@rochdev/explicit-libc
 
   linuxglibc-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-ia32') }}
@@ -157,7 +157,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-i386
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@rochdev/explicit-libc
 
   linuxglibc-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -171,7 +171,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@rochdev/explicit-libc
 
   linuxmusl-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-x64') }}
@@ -188,7 +188,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl tar zstd
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@rochdev/explicit-libc
 
   linuxmusl-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-arm64') }}
@@ -206,7 +206,7 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@rochdev/explicit-libc
 
   # TODO: linuxmusl-arm
 
@@ -219,7 +219,7 @@ jobs:
       ARCH: arm64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@rochdev/explicit-libc
 
   darwin-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'darwin-x64') }}
@@ -230,7 +230,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@rochdev/explicit-libc
 
   win32-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-ia32') }}
@@ -241,7 +241,7 @@ jobs:
       ARCH: ia32
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@rochdev/explicit-libc
 
   win32-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-x64') }}
@@ -252,7 +252,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@rochdev/explicit-libc
 
   # Tests
 
@@ -272,7 +272,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@rochdev/explicit-libc
 
   linux-arm64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -287,7 +287,7 @@ jobs:
     name: linux-arm64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@rochdev/explicit-libc
 
   linux-x64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -302,7 +302,7 @@ jobs:
     name: linux-x64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@rochdev/explicit-libc
 
   darwin-x64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'darwin-x64') }}
@@ -346,7 +346,7 @@ jobs:
         if: ${{ matrix.node <= '14' }}
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@rochdev/explicit-libc
 
   win32-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'win32-x64') }}
@@ -365,7 +365,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@rochdev/explicit-libc
 
   # Prebuilds
 

--- a/platforms/index.js
+++ b/platforms/index.js
@@ -18,8 +18,11 @@ function match (platform, filter) {
   for (let [start, end] of filter.map(f => f.split('-'))) {
     start = start.replace('windows', 'win32').replace('macos', 'darwin')
 
-    if (platform.startsWith(start)) return true
-    if (platform.endsWith(end || start)) return true
+    if (end) {
+      if (platform.startsWith(start) && platform.endsWith(end)) return true
+    } else {
+      if (platform.startsWith(start) || platform.endsWith(start)) return true
+    }
   }
 
   return false

--- a/platforms/index.js
+++ b/platforms/index.js
@@ -2,7 +2,7 @@
 
 const { parseArgs } = require('node:util')
 
-const systems = ['darwin', 'linux', 'linuxglibc', 'linuxmusl', 'win32']
+const systems = ['darwin', 'linuxglibc', 'linuxmusl', 'win32']
 const architectures = ['arm', 'arm64', 'ia32', 'x64']
 const platforms = systems.flatMap(s => architectures.map(a => `${s}-${a}`))
 

--- a/platforms/index.js
+++ b/platforms/index.js
@@ -15,9 +15,14 @@ const { values } = parseArgs({
 })
 
 function match (platform, filter) {
-  return filter
-    .map(f => f.replace('windows', 'win32').replace('macos', 'darwin'))
-    .find(f => platform === f || platform.startsWith(filter) || platform.endsWith(filter))
+  for (let [start, end] of filter.map(f => f.split('-'))) {
+    start = start.replace('windows', 'win32').replace('macos', 'darwin')
+
+    if (platform.startsWith(start)) return true
+    if (platform.endsWith(end || start)) return true
+  }
+
+  return false
 }
 
 function output (platforms) {


### PR DESCRIPTION
This PR makes the `libc` target explicit to avoid errors on Alpine when a `musl` target doesn't exist and the `linux` target doesn't support Alpine.

Working CI:

https://github.com/DataDog/action-prebuildify/actions/runs/10966147909
https://github.com/DataDog/action-prebuildify/actions/runs/10966147913