### PR TITLE
Support node 23

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -287,9 +287,11 @@ jobs:
     container:
       image: centos:${{ matrix.node < 18 && '7' || '8' }}
     name: centos-test-${{ matrix.node }}
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: 'true'
     steps:
-      # checkout@v3/v4 use node 20 which doesn't run on centos 7
-      - uses: actions/checkout@v2
+      # checkout@v4 uses node 20 which doesn't run on centos 7
+      - uses: actions/checkout@v3
       - run: |
           curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
           . $HOME/.nvm/nvm.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
     env:
       ARCH: arm
       LIBC: glibc
-      DOCKER_BUILDER: node:20
+      DOCKER_BUILDER: rochdev/holy-node-box:12-arm32v7
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -136,7 +136,7 @@ jobs:
     env:
       ARCH: arm64
       LIBC: glibc
-      DOCKER_BUILDER: node:20
+      DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -154,7 +154,7 @@ jobs:
     env:
       ARCH: ia32
       LIBC: glibc
-      DOCKER_BUILDER: node:20
+      DOCKER_BUILDER: rochdev/holy-node-box:12-i386
     steps:
       - uses: actions/checkout@v4
       - uses: DataDog/action-prebuildify/prebuild@main
@@ -168,7 +168,7 @@ jobs:
     env:
       ARCH: x64
       LIBC: glibc
-      DOCKER_BUILDER: node:20
+      DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@v4
       - uses: DataDog/action-prebuildify/prebuild@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,9 +199,8 @@ jobs:
     env:
       ARCH: arm64
       LIBC: musl
-      DOCKER_BUILDER: node:20.0.0-alpine
+      DOCKER_BUILDER: uurien/node-to-build:20.0.0-alpine
     steps:
-      - run: apk update && apk add bash build-base git python3 curl tar zstd gcc
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -291,6 +291,7 @@ jobs:
         - /node20217:/__e/node20:ro,rshared
     name: centos-test-${{ matrix.node }}
     steps:
+      # https://github.com/actions/runner/issues/2906#issuecomment-2109514798
       - name: Install Node for runner (CentOS-compatible)
         run: |
           curl -LO https://unofficial-builds.nodejs.org/download/release/v20.9.0/node-v20.9.0-linux-x64-glibc-217.tar.xz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
     env:
       ARCH: arm
       LIBC: glibc
-      DOCKER_BUILDER: rochdev/holy-node-box:12-arm32v7
+      DOCKER_BUILDER: node:20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -136,7 +136,7 @@ jobs:
     env:
       ARCH: arm64
       LIBC: glibc
-      DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8
+      DOCKER_BUILDER: node:20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -154,7 +154,7 @@ jobs:
     env:
       ARCH: ia32
       LIBC: glibc
-      DOCKER_BUILDER: rochdev/holy-node-box:12-i386
+      DOCKER_BUILDER: node:20
     steps:
       - uses: actions/checkout@v4
       - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
@@ -168,7 +168,7 @@ jobs:
     env:
       ARCH: x64
       LIBC: glibc
-      DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
+      DOCKER_BUILDER: node:20
     steps:
       - uses: actions/checkout@v4
       - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -297,6 +297,7 @@ jobs:
           curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
           . $HOME/.nvm/nvm.sh
           nvm install ${{ matrix.node }}
+          npm install -g yarn@^1.22.22
         shell: bash
       - uses: DataDog/action-prebuildify/test@main
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -274,6 +274,29 @@ jobs:
       - uses: actions/checkout@v4
       - uses: DataDog/action-prebuildify/test@main
 
+  centos-test:
+    if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
+    strategy:
+      matrix:
+        node: ${{ fromJson(needs.versions.outputs.versions) }}
+    needs:
+      - versions
+      - prebuilds
+      - platforms
+    runs-on: ubuntu-latest
+    container:
+      image: centos:${{ matrix.node < 18 && '7' || '8' }}
+    name: alpine-test-${{ matrix.node }}
+    name: centos-test-${{ matrix.node }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+          . $HOME/.nvm/nvm.sh
+          nvm install ${{ matrix.node }}
+        shell: bash
+      - uses: DataDog/action-prebuildify/test@main
+
   linux-arm64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - id: versions
-        uses: DataDog/action-prebuildify/compute-matrix@main
+        uses: DataDog/action-prebuildify/compute-matrix@ugaitz/support-node-23
         with:
           min: ${{ inputs.min-node-version }}
 
@@ -104,7 +104,7 @@ jobs:
       platforms: ${{ steps.platforms.outputs.platforms }}
     steps:
       - id: platforms
-        uses: DataDog/action-prebuildify/platforms@main
+        uses: DataDog/action-prebuildify/platforms@ugaitz/support-node-23
         with:
           skip: ${{ inputs.skip }}
           only: ${{ inputs.only }}
@@ -125,7 +125,7 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
 
   linuxglibc-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -143,7 +143,7 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
 
   linuxglibc-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-ia32') }}
@@ -157,7 +157,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-i386
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
 
   linuxglibc-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -171,7 +171,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
 
   linuxmusl-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-x64') }}
@@ -188,7 +188,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl tar zstd
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
 
   linuxmusl-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-arm64') }}
@@ -206,7 +206,7 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
 
   # TODO: linuxmusl-arm
 
@@ -219,7 +219,7 @@ jobs:
       ARCH: arm64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
 
   darwin-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'darwin-x64') }}
@@ -230,7 +230,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
 
   win32-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-ia32') }}
@@ -241,7 +241,7 @@ jobs:
       ARCH: ia32
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
 
   win32-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-x64') }}
@@ -252,7 +252,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
 
   # Tests
 
@@ -272,7 +272,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@ugaitz/support-node-23
 
   linux-arm64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -287,7 +287,7 @@ jobs:
     name: linux-arm64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@ugaitz/support-node-23
 
   linux-x64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -302,7 +302,7 @@ jobs:
     name: linux-x64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@ugaitz/support-node-23
 
   darwin-x64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'darwin-x64') }}
@@ -346,7 +346,7 @@ jobs:
         if: ${{ matrix.node <= '14' }}
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@ugaitz/support-node-23
 
   win32-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'win32-x64') }}
@@ -365,7 +365,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@ugaitz/support-node-23
 
   # Prebuilds
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - id: versions
-        uses: DataDog/action-prebuildify/compute-matrix@main
+        uses: DataDog/action-prebuildify/compute-matrix@ugaitz/support-node-23
         with:
           min: ${{ inputs.min-node-version }}
 
@@ -104,7 +104,7 @@ jobs:
       platforms: ${{ steps.platforms.outputs.platforms }}
     steps:
       - id: platforms
-        uses: DataDog/action-prebuildify/platforms@main
+        uses: DataDog/action-prebuildify/platforms@ugaitz/support-node-23
         with:
           skip: ${{ inputs.skip }}
           only: ${{ inputs.only }}
@@ -125,7 +125,7 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
 
   linuxglibc-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -143,7 +143,7 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
 
   linuxglibc-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-ia32') }}
@@ -157,7 +157,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-i386
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
 
   linuxglibc-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -171,7 +171,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
 
   linuxmusl-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-x64') }}
@@ -188,7 +188,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl tar zstd
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
 
   linuxmusl-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-arm64') }}
@@ -206,7 +206,7 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
 
   # TODO: linuxmusl-arm
 
@@ -219,7 +219,7 @@ jobs:
       ARCH: arm64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
 
   darwin-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'darwin-x64') }}
@@ -230,7 +230,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
 
   win32-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-ia32') }}
@@ -241,7 +241,7 @@ jobs:
       ARCH: ia32
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
 
   win32-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-x64') }}
@@ -252,7 +252,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
 
   # Tests
 
@@ -272,7 +272,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@ugaitz/support-node-23
 
   centos-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -319,7 +319,7 @@ jobs:
     name: linux-arm64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@ugaitz/support-node-23
 
   linux-x64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -334,7 +334,7 @@ jobs:
     name: linux-x64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@ugaitz/support-node-23
 
   darwin-x64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'darwin-x64') }}
@@ -378,7 +378,7 @@ jobs:
         if: ${{ matrix.node <= '14' }}
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@ugaitz/support-node-23
 
   win32-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'win32-x64') }}
@@ -397,7 +397,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@ugaitz/support-node-23
 
   # Prebuilds
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -298,7 +298,7 @@ jobs:
           . $HOME/.nvm/nvm.sh
           nvm install ${{ matrix.node }}
           npm install -g yarn@^1.22.22
-          yarn global bin >> $GITHUB_PATH
+          dirname $(nvm which default) >> $GITHUB_PATH
         shell: bash
       - uses: DataDog/action-prebuildify/test@main
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -286,10 +286,10 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: centos:${{ matrix.node < 18 && '7' || '8' }}
+      volumes:
+        - /node20217:/node20217:rw,rshared
+        - /node20217:/__e/node20:ro,rshared
     name: centos-test-${{ matrix.node }}
-    env:
-      ACTIONS_RUNNER_FORCED_INTERNAL_NODE_VERSION: node16
-      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
     steps:
       # actions/checkout uses node 20 which doesn't run on centos 7
       - run: |
@@ -302,6 +302,7 @@ jobs:
           nvm install ${{ matrix.node }}
           npm install -g yarn@^1.22.22
           dirname $(nvm which default) >> $GITHUB_PATH
+          cp -r $(dirname $(nvm which default)) /node20217/bin
         shell: bash
       - uses: DataDog/action-prebuildify/test@main
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -288,8 +288,8 @@ jobs:
       image: centos:${{ matrix.node < 18 && '7' || '8' }}
     name: centos-test-${{ matrix.node }}
     steps:
-      # checkout@v4 uses node 20 which doesn't run on centos 7
-      - uses: actions/checkout@v3
+      # checkout@v3/v4 use node 20 which doesn't run on centos 7
+      - uses: actions/checkout@v2
       - run: |
           curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
           . $HOME/.nvm/nvm.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -297,12 +297,14 @@ jobs:
           tar --strip-components=1 -zxf repo.tar.gz
         shell: bash
       - run: |
+          curl -LO https://unofficial-builds.nodejs.org/download/release/v20.9.0/node-v20.9.0-linux-x64-glibc-217.tar.xz
+          tar -xf node-v20.9.0-linux-x64-glibc-217.tar.xz --strip-components 1 -C /node20217
+      - run: |
           curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
           . $HOME/.nvm/nvm.sh
           nvm install ${{ matrix.node }}
           npm install -g yarn@^1.22.22
           dirname $(nvm which default) >> $GITHUB_PATH
-          cp -r $(dirname $(nvm which default)) /node20217/bin
         shell: bash
       - uses: DataDog/action-prebuildify/test@main
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,7 +295,7 @@ jobs:
         run: |
           curl -LO https://unofficial-builds.nodejs.org/download/release/v20.9.0/node-v20.9.0-linux-x64-glibc-217.tar.xz
           tar -xf node-v20.9.0-linux-x64-glibc-217.tar.xz --strip-components 1 -C /node20217
-      - run: actions/checkout@v4
+      - uses: actions/checkout@v4
       - name: Install Node for tests
         run: |
           curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -291,22 +291,20 @@ jobs:
         - /node20217:/__e/node20:ro,rshared
     name: centos-test-${{ matrix.node }}
     steps:
-      # actions/checkout uses node 20 which doesn't run on centos 7
-      - run: |
-          curl -o repo.tar.gz https://github.com/${{ github.repository }}/archive/${{ github.ref }}.tar.gz -JLO
-          tar --strip-components=1 -zxf repo.tar.gz
-        shell: bash
-      - run: |
+      - name: Install Node for runner (CentOS-compatible)
+        run: |
           curl -LO https://unofficial-builds.nodejs.org/download/release/v20.9.0/node-v20.9.0-linux-x64-glibc-217.tar.xz
           tar -xf node-v20.9.0-linux-x64-glibc-217.tar.xz --strip-components 1 -C /node20217
-      - run: |
+      - run: actions/checkout@v4
+      - name: Install Node for tests
+        run: |
           curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
           . $HOME/.nvm/nvm.sh
           nvm install ${{ matrix.node }}
           npm install -g yarn@^1.22.22
           dirname $(nvm which default) >> $GITHUB_PATH
         shell: bash
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@ugaitz/support-node-23
 
   linux-arm64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - id: versions
-        uses: DataDog/action-prebuildify/compute-matrix@ugaitz/support-node-23
+        uses: DataDog/action-prebuildify/compute-matrix@main
         with:
           min: ${{ inputs.min-node-version }}
 
@@ -104,7 +104,7 @@ jobs:
       platforms: ${{ steps.platforms.outputs.platforms }}
     steps:
       - id: platforms
-        uses: DataDog/action-prebuildify/platforms@ugaitz/support-node-23
+        uses: DataDog/action-prebuildify/platforms@main
         with:
           skip: ${{ inputs.skip }}
           only: ${{ inputs.only }}
@@ -125,7 +125,7 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxglibc-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -143,7 +143,7 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxglibc-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-ia32') }}
@@ -157,7 +157,7 @@ jobs:
       DOCKER_BUILDER: node:20
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxglibc-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -171,7 +171,7 @@ jobs:
       DOCKER_BUILDER: node:20
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxmusl-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-x64') }}
@@ -188,7 +188,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl tar zstd
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxmusl-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-arm64') }}
@@ -206,7 +206,7 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # TODO: linuxmusl-arm
 
@@ -219,7 +219,7 @@ jobs:
       ARCH: arm64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   darwin-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'darwin-x64') }}
@@ -230,7 +230,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   win32-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-ia32') }}
@@ -241,7 +241,7 @@ jobs:
       ARCH: ia32
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   win32-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-x64') }}
@@ -252,7 +252,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # Tests
 
@@ -272,7 +272,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/test@main
 
   linux-arm64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -287,7 +287,7 @@ jobs:
     name: linux-arm64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/test@main
 
   linux-x64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -302,7 +302,7 @@ jobs:
     name: linux-x64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/test@main
 
   darwin-x64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'darwin-x64') }}
@@ -346,7 +346,7 @@ jobs:
         if: ${{ matrix.node <= '14' }}
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/test@main
 
   win32-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'win32-x64') }}
@@ -365,7 +365,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/test@main
 
   # Prebuilds
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - id: versions
-        uses: DataDog/action-prebuildify/compute-matrix@ugaitz/support-node-23
+        uses: DataDog/action-prebuildify/compute-matrix@main
         with:
           min: ${{ inputs.min-node-version }}
 
@@ -104,7 +104,7 @@ jobs:
       platforms: ${{ steps.platforms.outputs.platforms }}
     steps:
       - id: platforms
-        uses: DataDog/action-prebuildify/platforms@ugaitz/support-node-23
+        uses: DataDog/action-prebuildify/platforms@main
         with:
           skip: ${{ inputs.skip }}
           only: ${{ inputs.only }}
@@ -125,7 +125,7 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxglibc-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -143,7 +143,7 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxglibc-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-ia32') }}
@@ -157,7 +157,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-i386
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxglibc-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -171,7 +171,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxmusl-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-x64') }}
@@ -188,7 +188,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl tar zstd
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxmusl-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-arm64') }}
@@ -206,7 +206,7 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # TODO: linuxmusl-arm
 
@@ -219,7 +219,7 @@ jobs:
       ARCH: arm64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   darwin-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'darwin-x64') }}
@@ -230,7 +230,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   win32-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-ia32') }}
@@ -241,7 +241,7 @@ jobs:
       ARCH: ia32
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   win32-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-x64') }}
@@ -252,7 +252,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # Tests
 
@@ -272,7 +272,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/test@main
 
   centos-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -305,7 +305,7 @@ jobs:
           npm install -g yarn@^1.22.22
           dirname $(nvm which default) >> $GITHUB_PATH
         shell: bash
-      - uses: DataDog/action-prebuildify/test@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/test@main
 
   linux-arm64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -320,7 +320,7 @@ jobs:
     name: linux-arm64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/test@main
 
   linux-x64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -335,7 +335,7 @@ jobs:
     name: linux-x64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/test@main
 
   darwin-x64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'darwin-x64') }}
@@ -379,7 +379,7 @@ jobs:
         if: ${{ matrix.node <= '14' }}
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/test@main
 
   win32-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'win32-x64') }}
@@ -398,7 +398,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@ugaitz/support-node-23
+      - uses: DataDog/action-prebuildify/test@main
 
   # Prebuilds
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -287,6 +287,9 @@ jobs:
     container:
       image: centos:${{ matrix.node < 18 && '7' || '8' }}
     name: centos-test-${{ matrix.node }}
+    env:
+      ACTIONS_RUNNER_FORCED_INTERNAL_NODE_VERSION: node16
+      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
     steps:
       # actions/checkout uses node 20 which doesn't run on centos 7
       - run: |
@@ -299,7 +302,6 @@ jobs:
           nvm install ${{ matrix.node }}
           npm install -g yarn@^1.22.22
           dirname $(nvm which default) >> $GITHUB_PATH
-          cp $(nvm which default) /__e/node20/bin/node
         shell: bash
       - uses: DataDog/action-prebuildify/test@main
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,8 +199,9 @@ jobs:
     env:
       ARCH: arm64
       LIBC: musl
-      DOCKER_BUILDER: uurien/node-to-build:20.0.0-alpine
+      DOCKER_BUILDER: node:20.0.0-alpine
     steps:
+      - run: apk update && apk add bash build-base git python3 curl tar zstd gcc
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -298,6 +298,7 @@ jobs:
           . $HOME/.nvm/nvm.sh
           nvm install ${{ matrix.node }}
           npm install -g yarn@^1.22.22
+          yarn global bin >> $GITHUB_PATH
         shell: bash
       - uses: DataDog/action-prebuildify/test@main
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -299,6 +299,7 @@ jobs:
           nvm install ${{ matrix.node }}
           npm install -g yarn@^1.22.22
           dirname $(nvm which default) >> $GITHUB_PATH
+          cp $(nvm which default) /__e/node20/bin/node
         shell: bash
       - uses: DataDog/action-prebuildify/test@main
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -286,7 +286,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: centos:${{ matrix.node < 18 && '7' || '8' }}
-    name: alpine-test-${{ matrix.node }}
     name: centos-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -287,11 +287,12 @@ jobs:
     container:
       image: centos:${{ matrix.node < 18 && '7' || '8' }}
     name: centos-test-${{ matrix.node }}
-    env:
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: 'true'
     steps:
-      # checkout@v4 uses node 20 which doesn't run on centos 7
-      - uses: actions/checkout@v3
+      # actions/checkout uses node 20 which doesn't run on centos 7
+      - run: |
+          curl -o repo.tar.gz https://github.com/${{ github.repository }}/archive/${{ github.ref }}.tar.gz -JLO
+          tar --strip-components=1 -zxf repo.tar.gz
+        shell: bash
       - run: |
           curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
           . $HOME/.nvm/nvm.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -288,7 +288,8 @@ jobs:
       image: centos:${{ matrix.node < 18 && '7' || '8' }}
     name: centos-test-${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v4
+      # checkout@v4 uses node 20 which doesn't run on centos 7
+      - uses: actions/checkout@v3
       - run: |
           curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
           . $HOME/.nvm/nvm.sh

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ GitHub Actions reusable workflow to generate prebuilds for a Node native add-on.
 
 ## Usage
 
-This workflow can be used to generate Node 12 - 19 prebuilds for Linux, macOS
+This workflow can be used to generate Node 12 - 23 prebuilds for Linux, macOS
 and Windows. The prebuilds will be stored in the `prebuilds` folder which should
 be added to `.gitignore`, and can be loaded using
 [node-gyp-build](https://www.npmjs.com/package/node-gyp-build) with

--- a/binding.gyp
+++ b/binding.gyp
@@ -10,7 +10,7 @@
     "xcode_settings": {
       "MACOSX_DEPLOYMENT_TARGET": "10.10",
       "OTHER_CFLAGS": [
-        "-std=c++17",
+        "-std=c++20",
         "-stdlib=libc++",
         "-Wall"
       ]
@@ -18,7 +18,7 @@
     "conditions": [
       ["OS == 'linux'", {
         "cflags": [
-          "-std=c++11",
+          "-std=c++20",
           "-Wall"
         ],
         "cflags_cc": [

--- a/binding.gyp
+++ b/binding.gyp
@@ -17,14 +17,14 @@
     },
     "conditions": [
       ["OS == 'linux'", {
-        "cflags!": [
-          "-std=gnu++20"
-        ],
         "cflags": [
-          "-std=c++2a",
           "-Wall"
         ],
+        "cflags_cc!": [
+          "-std=gnu++20"
+        ],
         "cflags_cc": [
+          "-std=gnu++2a",
           "-Wno-cast-function-type"
         ]
       }],

--- a/binding.gyp
+++ b/binding.gyp
@@ -18,7 +18,7 @@
     "conditions": [
       ["OS == 'linux'", {
         "cflags": [
-          "-std=c++20",
+          "-std=c++2a",
           "-Wall"
         ],
         "cflags_cc": [

--- a/binding.gyp
+++ b/binding.gyp
@@ -17,6 +17,9 @@
     },
     "conditions": [
       ["OS == 'linux'", {
+        "cflags!": [
+          "-std=gnu++20"
+        ],
         "cflags": [
           "-std=c++2a",
           "-Wall"
@@ -28,7 +31,7 @@
       ["OS == 'win'", {
         "cflags": [],
         'defines': [
-            'NOMINMAX' # allow std::min/max to work
+          'NOMINMAX' # allow std::min/max to work
         ],
       }]
     ]

--- a/compute-matrix/action.yml
+++ b/compute-matrix/action.yml
@@ -6,7 +6,7 @@ inputs:
     default: '12'
   max:
     description: The maximum Node.js version to include in the matrix
-    default: '22'
+    default: '23'
   step:
     description: Major version step between LTS releases
     default: '2'

--- a/compute-matrix/index.js
+++ b/compute-matrix/index.js
@@ -6,7 +6,7 @@ const { values } = parseArgs({
   args: process.argv.slice(2),
   options: {
     min: { type: 'string', default: '12' },
-    max: { type: 'string', default: '22' },
+    max: { type: 'string', default: '23' },
     step: { type: 'string', default: '2' }
   }
 })

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "node test"
   },
   "dependencies": {
-    "nan": "^2.19.0",
+    "nan": "^2.22.0",
     "node-gyp-build": "^3.9.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "nan": "^2.22.0",
-    "node-gyp-build": "^4.8.2"
+    "node-gyp-build": "^3.9.0"
   },
   "devDependencies": {
     "eslint": "^7.31.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "nan": "^2.22.0",
-    "node-gyp-build": "^3.9.0"
+    "node-gyp-build": "^4.8.2"
   },
   "devDependencies": {
     "eslint": "^7.31.0",

--- a/prebuild/targets.js
+++ b/prebuild/targets.js
@@ -13,7 +13,8 @@ const nodeTargets = [
   { version: '19.0.0', abi: '111' },
   { version: '20.0.0', abi: '115' },
   { version: '21.0.0', abi: '120' },
-  { version: '22.0.0', abi: '127' }
+  { version: '22.0.0', abi: '127' },
+  { version: '23.0.0', abi: '131' }
 ]
 
 function getFilteredNodeTargets (semverConstraint) {

--- a/test/action.yml
+++ b/test/action.yml
@@ -8,11 +8,11 @@ runs:
       shell: bash
       working-directory: ${{ env.DIRECTORY_PATH }}
     - run: $PACKAGE_MANAGER install --ignore-scripts
-      shell: bash -l {0}
+      shell: bash
       working-directory: ${{ env.DIRECTORY_PATH }}
     - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       if: ${{ env.NAPI_RS == 'true' }}
       shell: bash
     - run: $PACKAGE_MANAGER test
-      shell: bash -l {0}
+      shell: bash
       working-directory: ${{ env.DIRECTORY_PATH }}

--- a/test/action.yml
+++ b/test/action.yml
@@ -8,11 +8,11 @@ runs:
       shell: bash
       working-directory: ${{ env.DIRECTORY_PATH }}
     - run: $PACKAGE_MANAGER install --ignore-scripts
-      shell: bash
+      shell: bash -l {0}
       working-directory: ${{ env.DIRECTORY_PATH }}
     - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       if: ${{ env.NAPI_RS == 'true' }}
       shell: bash
     - run: $PACKAGE_MANAGER test
-      shell: bash
+      shell: bash -l {0}
       working-directory: ${{ env.DIRECTORY_PATH }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -906,10 +906,10 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nan@^2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.19.0.tgz#bb58122ad55a6c5bc973303908d5b16cfdd5a8c0"
-  integrity sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==
+nan@^2.22.0:
+  version "2.22.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.22.0.tgz#31bc433fc33213c97bad36404bb68063de604de3"
+  integrity sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==
 
 natural-compare@^1.4.0:
   version "1.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -916,10 +916,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-node-gyp-build@^3.9.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-3.9.0.tgz#53a350187dd4d5276750da21605d1cb681d09e25"
-  integrity sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==
+node-gyp-build@^4.8.2:
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.2.tgz#4f802b71c1ab2ca16af830e6c1ea7dd1ad9496fa"
+  integrity sha512-IRUxE4BVsHWXkV/SFOut4qTlagw2aM8T5/vnTsmrHJvVoKueJHRc/JaFND7QDDc61kLYUJ6qlZM3sqTSyx2dTw==
 
 object-inspect@^1.12.0, object-inspect@^1.9.0:
   version "1.12.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -916,10 +916,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-node-gyp-build@^4.8.2:
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.2.tgz#4f802b71c1ab2ca16af830e6c1ea7dd1ad9496fa"
-  integrity sha512-IRUxE4BVsHWXkV/SFOut4qTlagw2aM8T5/vnTsmrHJvVoKueJHRc/JaFND7QDDc61kLYUJ6qlZM3sqTSyx2dTw==
+node-gyp-build@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-3.9.0.tgz#53a350187dd4d5276750da21605d1cb681d09e25"
+  integrity sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==
 
 object-inspect@^1.12.0, object-inspect@^1.9.0:
   version "1.12.0"


### PR DESCRIPTION
Add support for node 23.

### Changes
- Change references to support node 23
- node 23 requires c++20 to build, changed the bindings.yml to support it
- node 12 can not build using c++20, using node:20 docker image to build


[Commit ](https://github.com/DataDog/action-prebuildify/pull/57/commits/0a47d1bf9cb7477ceabf316057dba485742982c9) pointing to a green CI before restoring `@main` branch in actions.