### PR TITLE
note in readme about required node-gyp-build version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ be added to `.gitignore`, and can be loaded using
 [node-gyp-build](https://www.npmjs.com/package/node-gyp-build) with
 `require('node-gyp-build')(__dirname)`.
 
+> *NOTE:* Currently, `node-gyp-build` must be `<4` to work with this action.
+
 Example usage with the available options and the defaults:
 
 ```yaml


### PR DESCRIPTION
`node-gyp-build@4` introduced an incompatible directory structure, so right now we're stuck on the older version. Documenting this since otherwise it's not clear why builds might fail if you just `npm install node-gyp-build`.