### PR TITLE
always use nvm to manage node test version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -272,7 +272,9 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@rochdev/nvm-all-the-things
+        with:
+          node: ${{ matrix.node }}
 
   centos-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -297,15 +299,9 @@ jobs:
           curl -LO https://unofficial-builds.nodejs.org/download/release/v20.9.0/node-v20.9.0-linux-x64-glibc-217.tar.xz
           tar -xf node-v20.9.0-linux-x64-glibc-217.tar.xz --strip-components 1 -C /node20217
       - uses: actions/checkout@v4
-      - name: Install Node for tests
-        run: |
-          curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
-          . $HOME/.nvm/nvm.sh
-          nvm install ${{ matrix.node }}
-          npm install -g yarn@^1.22.22
-          dirname $(nvm which default) >> $GITHUB_PATH
-        shell: bash
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@rochdev/nvm-all-the-things
+        with:
+          node: ${{ matrix.node }}
 
   linux-arm64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -320,7 +316,9 @@ jobs:
     name: linux-arm64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@rochdev/nvm-all-the-things
+        with:
+          node: ${{ matrix.node }}
 
   linux-x64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -335,7 +333,9 @@ jobs:
     name: linux-x64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@rochdev/nvm-all-the-things
+        with:
+          node: ${{ matrix.node }}
 
   darwin-x64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'darwin-x64') }}
@@ -379,7 +379,9 @@ jobs:
         if: ${{ matrix.node <= '14' }}
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@rochdev/nvm-all-the-things
+        with:
+          node: ${{ matrix.node }}
 
   win32-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'win32-x64') }}
@@ -398,7 +400,9 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@rochdev/nvm-all-the-things
+        with:
+          node: ${{ matrix.node }}
 
   # Prebuilds
 

--- a/test/action.yml
+++ b/test/action.yml
@@ -1,6 +1,18 @@
 runs:
   using: composite
+  inputs:
+    node:
+      description: The version of Node to use for tests
+      required: true
   steps:
+    - name: Install Node for tests
+      run: |
+        curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+        . $HOME/.nvm/nvm.sh
+        nvm install ${{ inputs.node }}
+        npm install -g yarn@^1.22.22
+        dirname $(nvm which default) >> $GITHUB_PATH
+      shell: bash
     - uses: actions/download-artifact@v4
       with:
         path: ${{ env.DIRECTORY_PATH }}


### PR DESCRIPTION
We can't rely on the default version or the version installed by `setup-node` because it may need a different version than us, and it also doesn't support installing some older versions that we still support.