### PR TITLE
fix macos build for arm64

### DIFF
--- a/prebuild/index.js
+++ b/prebuild/index.js
@@ -39,8 +39,7 @@ const napiTargets = {
   'linuxglibc-x64': 'x86_64-unknown-linux-gnu',
   'linuxmusl-x64': 'x86_64-unknown-linux-musl',
   'linuxmusl-arm64': 'aarch64-unknown-linux-musl',
-  // x86_64-apple-darwin is universal macOS, aarch64-apple-darwin is iOS
-  'darwin-arm64': 'x86_64-apple-darwin',
+  'darwin-arm64': 'aarch64-apple-darwin',
   'darwin-x64': 'x86_64-apple-darwin',
   'win32-ia32': 'i686-pc-windows-msvc',
   'win32-x64': 'x86_64-pc-windows-msvc'


### PR DESCRIPTION
Fix macOS build for arm64. It turns out `aarch64-apple-darwin` is now supported for macOS and also required for cargo to properly detect the architecture.

This is currently not tested in CI, and adding that is out of the scope of this PR. I downloaded the artifact and made sure that it is now properly built for ARM64. Here is the output of `file`: `node-napi.node: Mach-O 64-bit dynamically linked shared library arm64`.

Working CI:

https://github.com/DataDog/action-prebuildify/actions/runs/11821033703
https://github.com/DataDog/action-prebuildify/actions/runs/11821033690
https://github.com/DataDog/action-prebuildify/actions/runs/11821033675