### PR TITLE
fix usage of deprecated macos runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,7 +223,7 @@ jobs:
 
   darwin-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'darwin-x64') }}
-    runs-on: macos-12
+    runs-on: macos-13
     needs:
       - platforms
     env:
@@ -351,7 +351,7 @@ jobs:
       - versions
       - prebuilds
       - platforms
-    runs-on: macos-12
+    runs-on: macos-13
     name: darwin-x64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
It has been deprecated for a few months and seems to now have been completely removed.