### PR TITLE
switch to alpine 3.11 to build musl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,7 @@ jobs:
     env:
       ARCH: x64
       LIBC: musl
-      DOCKER_BUILDER: rochdev/holy-node-box:12-amd64-beta
+      DOCKER_BUILDER: rochdev/holy-node-box:12-amd64-alpine
     steps:
       - uses: actions/checkout@v4
       - uses: DataDog/action-prebuildify/prebuild@alpine-3.13
@@ -188,7 +188,7 @@ jobs:
     env:
       ARCH: arm64
       LIBC: musl
-      DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8-beta
+      DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8-alpine
     steps:
       - uses: actions/checkout@v4
       - uses: DataDog/action-prebuildify/prebuild@alpine-3.13

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,8 +177,7 @@ jobs:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-x64') }}
     runs-on: ubuntu-latest
     container:
-      # musl is statically linked so we can use more recent version of image.
-      image: node:20.0.0-alpine
+      image: node:12-alpine3.13
     name: linuxmusl-x64
     needs:
       - platforms

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,16 +168,14 @@ jobs:
   linuxmusl-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-x64') }}
     runs-on: ubuntu-latest
-    container:
-      image: node:12-alpine3.13
     name: linuxmusl-x64
     needs:
       - platforms
     env:
       ARCH: x64
       LIBC: musl
+      DOCKER_BUILDER: rochdev/holy-node-box:12-amd64-beta
     steps:
-      - run: apk update && apk add bash build-base git python3 curl tar zstd
       - uses: actions/checkout@v4
       - uses: DataDog/action-prebuildify/prebuild@alpine-3.13
 
@@ -190,8 +188,7 @@ jobs:
     env:
       ARCH: arm64
       LIBC: musl
-      DOCKER_BUILDER: node:12-alpine3.13
-      PREBUILD: apk update && apk add bash build-base git python3 curl tar zstd
+      DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8-beta
     steps:
       - uses: actions/checkout@v4
       - uses: DataDog/action-prebuildify/prebuild@alpine-3.13

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,7 +198,8 @@ jobs:
     env:
       ARCH: arm64
       LIBC: musl
-      DOCKER_BUILDER: uurien/node-to-build:20.0.0-alpine
+      DOCKER_BUILDER: node:12-alpine3.13
+      PREBUILD: apk update && apk add bash build-base git python3 curl tar zstd
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - id: versions
-        uses: DataDog/action-prebuildify/compute-matrix@main
+        uses: DataDog/action-prebuildify/compute-matrix@alpine-3.13
         with:
           min: ${{ inputs.min-node-version }}
 
@@ -104,7 +104,7 @@ jobs:
       platforms: ${{ steps.platforms.outputs.platforms }}
     steps:
       - id: platforms
-        uses: DataDog/action-prebuildify/platforms@main
+        uses: DataDog/action-prebuildify/platforms@alpine-3.13
         with:
           skip: ${{ inputs.skip }}
           only: ${{ inputs.only }}
@@ -125,7 +125,7 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@alpine-3.13
 
   linuxglibc-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -143,7 +143,7 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@alpine-3.13
 
   linuxglibc-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-ia32') }}
@@ -157,7 +157,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-i386
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@alpine-3.13
 
   linuxglibc-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -171,7 +171,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@alpine-3.13
 
   linuxmusl-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-x64') }}
@@ -187,7 +187,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl tar zstd
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@alpine-3.13
 
   linuxmusl-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-arm64') }}
@@ -206,7 +206,7 @@ jobs:
         with:
           node-version: 18
       - run: npm i -g yarn
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@alpine-3.13
 
   # TODO: linuxmusl-arm
 
@@ -219,7 +219,7 @@ jobs:
       ARCH: arm64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@alpine-3.13
 
   darwin-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'darwin-x64') }}
@@ -230,7 +230,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@alpine-3.13
 
   win32-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-ia32') }}
@@ -241,7 +241,7 @@ jobs:
       ARCH: ia32
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@alpine-3.13
 
   win32-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-x64') }}
@@ -252,7 +252,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@main
+      - uses: DataDog/action-prebuildify/prebuild@alpine-3.13
 
   # Tests
 
@@ -272,7 +272,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@alpine-3.13
 
   centos-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -306,7 +306,7 @@ jobs:
           npm install -g yarn@^1.22.22
           dirname $(nvm which default) >> $GITHUB_PATH
         shell: bash
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@alpine-3.13
 
   linux-arm64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -321,7 +321,7 @@ jobs:
     name: linux-arm64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@alpine-3.13
         with:
           node: ${{ matrix.node }}
 
@@ -338,7 +338,7 @@ jobs:
     name: linux-x64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@alpine-3.13
         with:
           node: ${{ matrix.node }}
 
@@ -384,7 +384,7 @@ jobs:
         if: ${{ matrix.node <= '14' }}
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@alpine-3.13
         with:
           node: ${{ matrix.node }}
 
@@ -405,7 +405,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@main
+      - uses: DataDog/action-prebuildify/test@alpine-3.13
         with:
           node: ${{ matrix.node }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
 
   linuxglibc-arm:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm') }}
-    runs-on: arm-4core-linux-arm-limited
+    runs-on: ubuntu-24.04-arm
     name: linuxglibc-arm
     needs:
       - platforms
@@ -121,15 +121,11 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm32v7
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18
-      - run: npm i -g yarn
       - uses: DataDog/action-prebuildify/prebuild@alpine-3.13
 
   linuxglibc-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
-    runs-on: arm-4core-linux-arm-limited
+    runs-on: ubuntu-24.04-arm
     name: linuxglibc-arm64
     needs:
       - platforms
@@ -139,10 +135,6 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18
-      - run: npm i -g yarn
       - uses: DataDog/action-prebuildify/prebuild@alpine-3.13
 
   linuxglibc-ia32:
@@ -191,7 +183,7 @@ jobs:
 
   linuxmusl-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-arm64') }}
-    runs-on: arm-4core-linux-arm-limited
+    runs-on: ubuntu-24.04-arm
     name: linuxmusl-arm64
     needs:
       - platforms
@@ -202,10 +194,6 @@ jobs:
       PREBUILD: apk update && apk add bash build-base git python3 curl tar zstd
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18
-      - run: npm i -g yarn
       - uses: DataDog/action-prebuildify/prebuild@alpine-3.13
 
   # TODO: linuxmusl-arm
@@ -317,7 +305,7 @@ jobs:
       - versions
       - prebuilds
       - platforms
-    runs-on: arm-4core-linux-arm-limited
+    runs-on: ubuntu-24.04-arm
     name: linux-arm64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - id: versions
-        uses: DataDog/action-prebuildify/compute-matrix@alpine-3.13
+        uses: DataDog/action-prebuildify/compute-matrix@main
         with:
           min: ${{ inputs.min-node-version }}
 
@@ -104,7 +104,7 @@ jobs:
       platforms: ${{ steps.platforms.outputs.platforms }}
     steps:
       - id: platforms
-        uses: DataDog/action-prebuildify/platforms@alpine-3.13
+        uses: DataDog/action-prebuildify/platforms@main
         with:
           skip: ${{ inputs.skip }}
           only: ${{ inputs.only }}
@@ -121,7 +121,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm32v7
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@alpine-3.13
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxglibc-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -135,7 +135,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@alpine-3.13
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxglibc-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-ia32') }}
@@ -149,7 +149,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-i386
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@alpine-3.13
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxglibc-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -163,7 +163,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@alpine-3.13
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxmusl-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-x64') }}
@@ -177,7 +177,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64-alpine
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@alpine-3.13
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   linuxmusl-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-arm64') }}
@@ -191,7 +191,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8-alpine
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@alpine-3.13
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # TODO: linuxmusl-arm
 
@@ -204,7 +204,7 @@ jobs:
       ARCH: arm64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@alpine-3.13
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   darwin-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'darwin-x64') }}
@@ -215,7 +215,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@alpine-3.13
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   win32-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-ia32') }}
@@ -226,7 +226,7 @@ jobs:
       ARCH: ia32
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@alpine-3.13
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   win32-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-x64') }}
@@ -237,7 +237,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/prebuild@alpine-3.13
+      - uses: DataDog/action-prebuildify/prebuild@main
 
   # Tests
 
@@ -257,7 +257,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@alpine-3.13
+      - uses: DataDog/action-prebuildify/test@main
 
   centos-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -291,7 +291,7 @@ jobs:
           npm install -g yarn@^1.22.22
           dirname $(nvm which default) >> $GITHUB_PATH
         shell: bash
-      - uses: DataDog/action-prebuildify/test@alpine-3.13
+      - uses: DataDog/action-prebuildify/test@main
 
   linux-arm64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -306,7 +306,7 @@ jobs:
     name: linux-arm64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@alpine-3.13
+      - uses: DataDog/action-prebuildify/test@main
         with:
           node: ${{ matrix.node }}
 
@@ -323,7 +323,7 @@ jobs:
     name: linux-x64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DataDog/action-prebuildify/test@alpine-3.13
+      - uses: DataDog/action-prebuildify/test@main
         with:
           node: ${{ matrix.node }}
 
@@ -369,7 +369,7 @@ jobs:
         if: ${{ matrix.node <= '14' }}
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@alpine-3.13
+      - uses: DataDog/action-prebuildify/test@main
         with:
           node: ${{ matrix.node }}
 
@@ -390,7 +390,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@alpine-3.13
+      - uses: DataDog/action-prebuildify/test@main
         with:
           node: ${{ matrix.node }}
 

--- a/prebuild/action.yml
+++ b/prebuild/action.yml
@@ -56,7 +56,7 @@ runs:
           -e LIBC="$LIBC" \
           -w /usr/action \
           $DOCKER_BUILDER \
-          /bin/sh -c 'yarn && cd /usr/workspace && yarn exec node /usr/action'
+          /bin/bash -c 'yarn && cd /usr/workspace && yarn exec node /usr/action'
       if: ${{ env.DOCKER_BUILDER != '' }}
       shell: bash
     - uses: actions/upload-artifact@v4

--- a/prebuild/action.yml
+++ b/prebuild/action.yml
@@ -56,7 +56,7 @@ runs:
           -e LIBC="$LIBC" \
           -w /usr/action \
           $DOCKER_BUILDER \
-          /bin/bash -c 'yarn && cd /usr/workspace && yarn exec node /usr/action'
+          /bin/sh -c 'yarn && cd /usr/workspace && yarn exec node /usr/action'
       if: ${{ env.DOCKER_BUILDER != '' }}
       shell: bash
     - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Switch to alpine 3.11 to build musl. It turns out some underlying dependencies are still dynamically linked so we can't use a newer version of Alpine to build.

Working CI:
https://github.com/DataDog/action-prebuildify/actions/runs/14269801212
https://github.com/DataDog/action-prebuildify/actions/runs/14269801210
https://github.com/DataDog/action-prebuildify/actions/runs/14269801187