### PR TITLE
add abi 137 target for node 24

### DIFF
--- a/prebuild/targets.js
+++ b/prebuild/targets.js
@@ -14,7 +14,8 @@ const nodeTargets = [
   { version: '20.0.0', abi: '115' },
   { version: '21.0.0', abi: '120' },
   { version: '22.0.0', abi: '127' },
-  { version: '23.0.0', abi: '131' }
+  { version: '23.0.0', abi: '131' },
+  { version: '24.0.0', abi: '137' }
 ]
 
 function getFilteredNodeTargets (semverConstraint) {


### PR DESCRIPTION
Full support cannot be tested right now as `nan` hasn't been updated yet. However, adding at least the target allows any projects using the action to at least build for Node 24 when using Node-API or napi-rs.