### PR TITLE
Add Dependabot config for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` to automatically check for updates to pinned GitHub Actions
- Checks daily and opens PRs when newer versions are available
- As recommended in #74, now that actions are pinned to SHA hashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)