### PR TITLE
Support Node.js v26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - id: versions
-        uses: DataDog/action-prebuildify/compute-matrix@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
+        uses: DataDog/action-prebuildify/compute-matrix@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
         with:
           min: ${{ inputs.min-node-version }}
 
@@ -127,7 +127,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm32v7
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
+      - uses: DataDog/action-prebuildify/prebuild@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
 
   linuxglibc-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -141,7 +141,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
+      - uses: DataDog/action-prebuildify/prebuild@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
 
   linuxglibc-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-ia32') }}
@@ -155,7 +155,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-i386
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
+      - uses: DataDog/action-prebuildify/prebuild@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
 
   linuxglibc-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -169,7 +169,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
+      - uses: DataDog/action-prebuildify/prebuild@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
 
   linuxmusl-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-x64') }}
@@ -183,7 +183,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64-alpine
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
+      - uses: DataDog/action-prebuildify/prebuild@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
 
   linuxmusl-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-arm64') }}
@@ -197,7 +197,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8-alpine
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
+      - uses: DataDog/action-prebuildify/prebuild@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
 
   linuxmusl-x64-alpine-3-17:
     if: ${{ !inputs.napi && !inputs.napi-rs && !inputs.neon && !inputs.rust && contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-x64') }}
@@ -212,7 +212,7 @@ jobs:
       PREBUILDS_DIR: linuxmusl-x64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305
+      - uses: DataDog/action-prebuildify/prebuild@47be3ae4cf3579a995a764540123fb7aa9ed074d
 
   linuxmusl-arm64-alpine-3-17:
     if: ${{ !inputs.napi && !inputs.napi-rs && !inputs.neon && !inputs.rust && contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-arm64') }}
@@ -227,7 +227,7 @@ jobs:
       PREBUILDS_DIR: linuxmusl-arm64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305
+      - uses: DataDog/action-prebuildify/prebuild@47be3ae4cf3579a995a764540123fb7aa9ed074d
 
   # TODO: linuxmusl-arm
 
@@ -240,7 +240,7 @@ jobs:
       ARCH: arm64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
+      - uses: DataDog/action-prebuildify/prebuild@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
 
   darwin-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'darwin-x64') }}
@@ -251,7 +251,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
+      - uses: DataDog/action-prebuildify/prebuild@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
 
   win32-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-ia32') }}
@@ -262,7 +262,7 @@ jobs:
       ARCH: ia32
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
+      - uses: DataDog/action-prebuildify/prebuild@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
 
   win32-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-x64') }}
@@ -273,7 +273,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
+      - uses: DataDog/action-prebuildify/prebuild@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
 
   # Tests
 
@@ -293,7 +293,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/test@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
+      - uses: DataDog/action-prebuildify/test@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
 
   centos-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -336,7 +336,7 @@ jobs:
           npm install -g yarn@^1.22.22
           dirname $(nvm which default) >> $GITHUB_PATH
         shell: bash
-      - uses: DataDog/action-prebuildify/test@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
+      - uses: DataDog/action-prebuildify/test@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
 
   linux-arm64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -351,7 +351,7 @@ jobs:
     name: linux-arm64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/test@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
+      - uses: DataDog/action-prebuildify/test@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
         with:
           node: ${{ matrix.node }}
 
@@ -368,7 +368,7 @@ jobs:
     name: linux-x64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/test@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
+      - uses: DataDog/action-prebuildify/test@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
         with:
           node: ${{ matrix.node }}
 
@@ -414,7 +414,7 @@ jobs:
         if: ${{ matrix.node <= '14' }}
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
+      - uses: DataDog/action-prebuildify/test@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
         with:
           node: ${{ matrix.node }}
 
@@ -435,7 +435,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
+      - uses: DataDog/action-prebuildify/test@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
         with:
           node: ${{ matrix.node }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - id: versions
-        uses: DataDog/action-prebuildify/compute-matrix@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
+        uses: DataDog/action-prebuildify/compute-matrix@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
         with:
           min: ${{ inputs.min-node-version }}
 
@@ -127,7 +127,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm32v7
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
+      - uses: DataDog/action-prebuildify/prebuild@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
 
   linuxglibc-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -141,7 +141,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
+      - uses: DataDog/action-prebuildify/prebuild@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
 
   linuxglibc-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-ia32') }}
@@ -155,7 +155,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-i386
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
+      - uses: DataDog/action-prebuildify/prebuild@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
 
   linuxglibc-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -169,7 +169,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
+      - uses: DataDog/action-prebuildify/prebuild@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
 
   linuxmusl-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-x64') }}
@@ -183,7 +183,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64-alpine
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
+      - uses: DataDog/action-prebuildify/prebuild@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
 
   linuxmusl-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-arm64') }}
@@ -197,7 +197,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8-alpine
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
+      - uses: DataDog/action-prebuildify/prebuild@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
 
   linuxmusl-x64-alpine-3-17:
     if: ${{ !inputs.napi && !inputs.napi-rs && !inputs.neon && !inputs.rust && contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-x64') }}
@@ -212,7 +212,7 @@ jobs:
       PREBUILDS_DIR: linuxmusl-x64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8
+      - uses: DataDog/action-prebuildify/prebuild@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305
 
   linuxmusl-arm64-alpine-3-17:
     if: ${{ !inputs.napi && !inputs.napi-rs && !inputs.neon && !inputs.rust && contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-arm64') }}
@@ -227,7 +227,7 @@ jobs:
       PREBUILDS_DIR: linuxmusl-arm64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8
+      - uses: DataDog/action-prebuildify/prebuild@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305
 
   # TODO: linuxmusl-arm
 
@@ -240,7 +240,7 @@ jobs:
       ARCH: arm64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
+      - uses: DataDog/action-prebuildify/prebuild@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
 
   darwin-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'darwin-x64') }}
@@ -251,7 +251,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
+      - uses: DataDog/action-prebuildify/prebuild@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
 
   win32-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-ia32') }}
@@ -262,7 +262,7 @@ jobs:
       ARCH: ia32
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
+      - uses: DataDog/action-prebuildify/prebuild@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
 
   win32-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-x64') }}
@@ -273,7 +273,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
+      - uses: DataDog/action-prebuildify/prebuild@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
 
   # Tests
 
@@ -293,7 +293,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/test@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
+      - uses: DataDog/action-prebuildify/test@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
 
   centos-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -336,7 +336,7 @@ jobs:
           npm install -g yarn@^1.22.22
           dirname $(nvm which default) >> $GITHUB_PATH
         shell: bash
-      - uses: DataDog/action-prebuildify/test@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
+      - uses: DataDog/action-prebuildify/test@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
 
   linux-arm64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -351,7 +351,7 @@ jobs:
     name: linux-arm64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/test@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
+      - uses: DataDog/action-prebuildify/test@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
         with:
           node: ${{ matrix.node }}
 
@@ -368,7 +368,7 @@ jobs:
     name: linux-x64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/test@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
+      - uses: DataDog/action-prebuildify/test@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
         with:
           node: ${{ matrix.node }}
 
@@ -414,7 +414,7 @@ jobs:
         if: ${{ matrix.node <= '14' }}
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
+      - uses: DataDog/action-prebuildify/test@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
         with:
           node: ${{ matrix.node }}
 
@@ -435,7 +435,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
+      - uses: DataDog/action-prebuildify/test@0104380dfe9f60ee9ed2c5a4cabb2241f15e9305 # main
         with:
           node: ${{ matrix.node }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - id: versions
-        uses: DataDog/action-prebuildify/compute-matrix@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
+        uses: DataDog/action-prebuildify/compute-matrix@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
         with:
           min: ${{ inputs.min-node-version }}
 
@@ -127,7 +127,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm32v7
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
+      - uses: DataDog/action-prebuildify/prebuild@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
 
   linuxglibc-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -141,7 +141,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
+      - uses: DataDog/action-prebuildify/prebuild@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
 
   linuxglibc-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-ia32') }}
@@ -155,7 +155,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-i386
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
+      - uses: DataDog/action-prebuildify/prebuild@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
 
   linuxglibc-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -169,7 +169,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
+      - uses: DataDog/action-prebuildify/prebuild@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
 
   linuxmusl-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-x64') }}
@@ -183,7 +183,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64-alpine
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
+      - uses: DataDog/action-prebuildify/prebuild@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
 
   linuxmusl-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-arm64') }}
@@ -197,7 +197,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8-alpine
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
+      - uses: DataDog/action-prebuildify/prebuild@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
 
   linuxmusl-x64-alpine-3-17:
     if: ${{ !inputs.napi && !inputs.napi-rs && !inputs.neon && !inputs.rust && contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-x64') }}
@@ -212,7 +212,7 @@ jobs:
       PREBUILDS_DIR: linuxmusl-x64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@47be3ae4cf3579a995a764540123fb7aa9ed074d
+      - uses: DataDog/action-prebuildify/prebuild@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8
 
   linuxmusl-arm64-alpine-3-17:
     if: ${{ !inputs.napi && !inputs.napi-rs && !inputs.neon && !inputs.rust && contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-arm64') }}
@@ -227,7 +227,7 @@ jobs:
       PREBUILDS_DIR: linuxmusl-arm64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@47be3ae4cf3579a995a764540123fb7aa9ed074d
+      - uses: DataDog/action-prebuildify/prebuild@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8
 
   # TODO: linuxmusl-arm
 
@@ -240,7 +240,7 @@ jobs:
       ARCH: arm64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
+      - uses: DataDog/action-prebuildify/prebuild@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
 
   darwin-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'darwin-x64') }}
@@ -251,7 +251,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
+      - uses: DataDog/action-prebuildify/prebuild@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
 
   win32-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-ia32') }}
@@ -262,7 +262,7 @@ jobs:
       ARCH: ia32
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
+      - uses: DataDog/action-prebuildify/prebuild@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
 
   win32-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-x64') }}
@@ -273,7 +273,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
+      - uses: DataDog/action-prebuildify/prebuild@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
 
   # Tests
 
@@ -293,7 +293,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/test@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
+      - uses: DataDog/action-prebuildify/test@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
 
   centos-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -312,8 +312,8 @@ jobs:
         - /node20217:/__e/node20:ro,rshared
     name: centos-test-${{ matrix.node }}
     steps:
-      - name: Install libatomic for Node 25 - CentOS 8 vault repos (EOL)
-        if: matrix.node == '25'
+      - name: Install libatomic for Node 25+ - CentOS 8 vault repos (EOL)
+        if: ${{ matrix.node >= 25 }}
         run: |
           for f in /etc/yum.repos.d/CentOS-*.repo; do
             sed -i -e 's|^mirrorlist=|#mirrorlist=|g' \
@@ -336,7 +336,7 @@ jobs:
           npm install -g yarn@^1.22.22
           dirname $(nvm which default) >> $GITHUB_PATH
         shell: bash
-      - uses: DataDog/action-prebuildify/test@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
+      - uses: DataDog/action-prebuildify/test@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
 
   linux-arm64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -351,7 +351,7 @@ jobs:
     name: linux-arm64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/test@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
+      - uses: DataDog/action-prebuildify/test@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
         with:
           node: ${{ matrix.node }}
 
@@ -368,7 +368,7 @@ jobs:
     name: linux-x64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/test@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
+      - uses: DataDog/action-prebuildify/test@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
         with:
           node: ${{ matrix.node }}
 
@@ -414,7 +414,7 @@ jobs:
         if: ${{ matrix.node <= '14' }}
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
+      - uses: DataDog/action-prebuildify/test@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
         with:
           node: ${{ matrix.node }}
 
@@ -435,7 +435,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
+      - uses: DataDog/action-prebuildify/test@571fc52f9bebfd32311afab61bdf7e8fd1eb04e8 # main
         with:
           node: ${{ matrix.node }}
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ GitHub Actions reusable workflow to generate prebuilds for a Node native add-on.
 
 ## Usage
 
-This workflow can be used to generate Node 12 - 25 prebuilds for Linux, macOS
+This workflow can be used to generate Node 12 - 26 prebuilds for Linux, macOS
 and Windows. The prebuilds will be stored in the `prebuilds` folder which should
 be added to `.gitignore`, and can be loaded using
 [node-gyp-build](https://www.npmjs.com/package/node-gyp-build) with

--- a/compute-matrix/action.yml
+++ b/compute-matrix/action.yml
@@ -6,7 +6,7 @@ inputs:
     default: '12'
   max:
     description: The maximum Node.js version to include in the matrix
-    default: '25'
+    default: '26'
   step:
     description: Major version step between LTS releases
     default: '2'

--- a/compute-matrix/index.js
+++ b/compute-matrix/index.js
@@ -6,7 +6,7 @@ const { values } = parseArgs({
   args: process.argv.slice(2),
   options: {
     min: { type: 'string', default: '12' },
-    max: { type: 'string', default: '25' },
+    max: { type: 'string', default: '26' },
     step: { type: 'string', default: '2' }
   }
 })

--- a/prebuild/targets.js
+++ b/prebuild/targets.js
@@ -16,7 +16,8 @@ const nodeTargets = [
   { version: '22.0.0', abi: '127', alpineVersion: '~3.14' },
   { version: '23.0.0', abi: '131', alpineVersion: '~3.14' },
   { version: '24.0.0', abi: '137', alpineVersion: '~3.14' },
-  { version: '25.0.0', abi: '141', alpineVersion: '~3.17' }
+  { version: '25.0.0', abi: '141', alpineVersion: '~3.17' },
+  { version: '26.0.0', abi: '147', alpineVersion: '~3.17' }
 ]
 
 const allowedAlpineVersions = getAllowedAlpineVersions()

--- a/test/action.yml
+++ b/test/action.yml
@@ -22,6 +22,9 @@ runs:
     - run: node -e "console.log(process.versions)"
       shell: bash
       working-directory: ${{ env.DIRECTORY_PATH }}
+    - run: command -v yarn || npm install -g yarn@^1.22.22
+      if: ${{ env.PACKAGE_MANAGER == 'yarn' }}
+      shell: bash
     - run: $PACKAGE_MANAGER install --ignore-scripts
       shell: bash
       working-directory: ${{ env.DIRECTORY_PATH }}


### PR DESCRIPTION
This PR aims to add support for Node.js v26.

After pinning temporary sha:
- ✅ [Test](https://github.com/DataDog/action-prebuildify/actions/runs/26094704091)
- ✅ [Node-api](https://github.com/DataDog/action-prebuildify/actions/runs/26094704132)
- ✅ [Project](https://github.com/DataDog/action-prebuildify/actions/runs/26094704163)
- ✅ [Neon](https://github.com/DataDog/action-prebuildify/actions/runs/26094704179)