### PR TITLE
Switch macOS test runner from x64 to arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -377,6 +377,11 @@ jobs:
     strategy:
       matrix:
         node: ${{ fromJson(needs.versions.outputs.versions) }}
+        # Node.js < 16 has no official macOS arm64 build (Apple Silicon
+        # support landed in Node 16), so setup-node cannot install them here.
+        exclude:
+          - node: 12
+          - node: 14
     needs:
       - versions
       - prebuilds
@@ -391,27 +396,13 @@ jobs:
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
 
       #########################################################################
-      # node-gyp < 10 is not compatible with python 3.12
-      #
-      # For node 16+, we need to install node-gyp@latest that is compatible
-      # with python 3.12
+      # node-gyp < 10 is not compatible with python 3.12, so for node 16+ we
+      # install node-gyp@latest. (Node 12/14 are excluded from this job above,
+      # as they have no macOS arm64 build.)
       # Instruct npm to use the global version.
       - run: |
           npm install -g node-gyp@latest
           npm explore npm/node_modules/@npmcli/run-script -g -- npm_config_global=false npm install node-gyp@latest
-        if: ${{ matrix.node > '14' }}
-      # For node 14, we need to install node-gyp@9, because node-gyp@10 is not
-      # compatible with node 14. By installing manually setuptools, we ensure
-      # that node-gyp@9 is compatible with python 3.12.
-      # Older node-gyp versions are not compatible with python 3.12 even with
-      # setuptools that's why we install node-gyp@9.
-      # nvm@6 refuses to use the local node-gyp version, hence we install it
-      # globally and instruct npm to use the global version.
-      - run: |
-          npm install -g node-gyp@9
-          npm config set node_gyp $(npm prefix -g)/lib/node_modules/node-gyp/bin/node-gyp.js
-          pip3 install --break-system-packages setuptools
-        if: ${{ matrix.node <= '14' }}
       #########################################################################
 
       - uses: DataDog/action-prebuildify/test@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -372,8 +372,8 @@ jobs:
         with:
           node: ${{ matrix.node }}
 
-  darwin-x64-test:
-    if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'darwin-x64') }}
+  darwin-arm64-test:
+    if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'darwin-arm64') }}
     strategy:
       matrix:
         node: ${{ fromJson(needs.versions.outputs.versions) }}
@@ -381,8 +381,8 @@ jobs:
       - versions
       - prebuilds
       - platforms
-    runs-on: macos-15-intel
-    name: darwin-x64-test-${{ matrix.node }}
+    runs-on: macos-15
+    name: darwin-arm64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - id: versions
-        uses: DataDog/action-prebuildify/compute-matrix@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
+        uses: DataDog/action-prebuildify/compute-matrix@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
         with:
           min: ${{ inputs.min-node-version }}
 
@@ -110,7 +110,7 @@ jobs:
       platforms: ${{ steps.platforms.outputs.platforms }}
     steps:
       - id: platforms
-        uses: DataDog/action-prebuildify/platforms@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
+        uses: DataDog/action-prebuildify/platforms@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
         with:
           skip: ${{ inputs.skip }}
           only: ${{ inputs.only }}
@@ -127,7 +127,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm32v7
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
+      - uses: DataDog/action-prebuildify/prebuild@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
 
   linuxglibc-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -141,7 +141,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
+      - uses: DataDog/action-prebuildify/prebuild@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
 
   linuxglibc-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-ia32') }}
@@ -155,7 +155,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-i386
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
+      - uses: DataDog/action-prebuildify/prebuild@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
 
   linuxglibc-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -169,7 +169,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
+      - uses: DataDog/action-prebuildify/prebuild@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
 
   linuxmusl-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-x64') }}
@@ -183,7 +183,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64-alpine
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
+      - uses: DataDog/action-prebuildify/prebuild@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
 
   linuxmusl-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-arm64') }}
@@ -197,7 +197,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8-alpine
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
+      - uses: DataDog/action-prebuildify/prebuild@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
 
   linuxmusl-x64-alpine-3-17:
     if: ${{ !inputs.napi && !inputs.napi-rs && !inputs.neon && !inputs.rust && contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-x64') }}
@@ -212,7 +212,7 @@ jobs:
       PREBUILDS_DIR: linuxmusl-x64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
+      - uses: DataDog/action-prebuildify/prebuild@c4c8dfb44e41a5a66d93256702ebea3a89556a35
 
   linuxmusl-arm64-alpine-3-17:
     if: ${{ !inputs.napi && !inputs.napi-rs && !inputs.neon && !inputs.rust && contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-arm64') }}
@@ -227,7 +227,7 @@ jobs:
       PREBUILDS_DIR: linuxmusl-arm64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
+      - uses: DataDog/action-prebuildify/prebuild@c4c8dfb44e41a5a66d93256702ebea3a89556a35
 
   # TODO: linuxmusl-arm
 
@@ -240,7 +240,7 @@ jobs:
       ARCH: arm64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
+      - uses: DataDog/action-prebuildify/prebuild@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
 
   darwin-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'darwin-x64') }}
@@ -251,7 +251,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
+      - uses: DataDog/action-prebuildify/prebuild@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
 
   win32-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-ia32') }}
@@ -262,7 +262,7 @@ jobs:
       ARCH: ia32
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
+      - uses: DataDog/action-prebuildify/prebuild@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
 
   win32-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-x64') }}
@@ -273,7 +273,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
+      - uses: DataDog/action-prebuildify/prebuild@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
 
   # Tests
 
@@ -293,7 +293,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/test@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
+      - uses: DataDog/action-prebuildify/test@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
 
   centos-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -336,7 +336,7 @@ jobs:
           npm install -g yarn@^1.22.22
           dirname $(nvm which default) >> $GITHUB_PATH
         shell: bash
-      - uses: DataDog/action-prebuildify/test@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
+      - uses: DataDog/action-prebuildify/test@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
 
   linux-arm64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -351,7 +351,7 @@ jobs:
     name: linux-arm64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/test@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
+      - uses: DataDog/action-prebuildify/test@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
         with:
           node: ${{ matrix.node }}
 
@@ -368,7 +368,7 @@ jobs:
     name: linux-x64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/test@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
+      - uses: DataDog/action-prebuildify/test@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
         with:
           node: ${{ matrix.node }}
 
@@ -405,7 +405,7 @@ jobs:
           npm explore npm/node_modules/@npmcli/run-script -g -- npm_config_global=false npm install node-gyp@latest
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
+      - uses: DataDog/action-prebuildify/test@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
         with:
           node: ${{ matrix.node }}
 
@@ -426,7 +426,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
+      - uses: DataDog/action-prebuildify/test@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
         with:
           node: ${{ matrix.node }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - id: versions
-        uses: DataDog/action-prebuildify/compute-matrix@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
+        uses: DataDog/action-prebuildify/compute-matrix@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
         with:
           min: ${{ inputs.min-node-version }}
 
@@ -110,7 +110,7 @@ jobs:
       platforms: ${{ steps.platforms.outputs.platforms }}
     steps:
       - id: platforms
-        uses: DataDog/action-prebuildify/platforms@47be3ae4cf3579a995a764540123fb7aa9ed074d # main
+        uses: DataDog/action-prebuildify/platforms@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
         with:
           skip: ${{ inputs.skip }}
           only: ${{ inputs.only }}
@@ -127,7 +127,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm32v7
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
+      - uses: DataDog/action-prebuildify/prebuild@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
 
   linuxglibc-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -141,7 +141,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
+      - uses: DataDog/action-prebuildify/prebuild@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
 
   linuxglibc-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-ia32') }}
@@ -155,7 +155,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-i386
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
+      - uses: DataDog/action-prebuildify/prebuild@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
 
   linuxglibc-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -169,7 +169,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
+      - uses: DataDog/action-prebuildify/prebuild@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
 
   linuxmusl-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-x64') }}
@@ -183,7 +183,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64-alpine
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
+      - uses: DataDog/action-prebuildify/prebuild@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
 
   linuxmusl-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-arm64') }}
@@ -197,7 +197,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8-alpine
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
+      - uses: DataDog/action-prebuildify/prebuild@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
 
   linuxmusl-x64-alpine-3-17:
     if: ${{ !inputs.napi && !inputs.napi-rs && !inputs.neon && !inputs.rust && contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-x64') }}
@@ -212,7 +212,7 @@ jobs:
       PREBUILDS_DIR: linuxmusl-x64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@c4c8dfb44e41a5a66d93256702ebea3a89556a35
+      - uses: DataDog/action-prebuildify/prebuild@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
 
   linuxmusl-arm64-alpine-3-17:
     if: ${{ !inputs.napi && !inputs.napi-rs && !inputs.neon && !inputs.rust && contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-arm64') }}
@@ -227,7 +227,7 @@ jobs:
       PREBUILDS_DIR: linuxmusl-arm64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@c4c8dfb44e41a5a66d93256702ebea3a89556a35
+      - uses: DataDog/action-prebuildify/prebuild@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
 
   # TODO: linuxmusl-arm
 
@@ -240,7 +240,7 @@ jobs:
       ARCH: arm64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
+      - uses: DataDog/action-prebuildify/prebuild@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
 
   darwin-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'darwin-x64') }}
@@ -251,7 +251,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
+      - uses: DataDog/action-prebuildify/prebuild@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
 
   win32-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-ia32') }}
@@ -262,7 +262,7 @@ jobs:
       ARCH: ia32
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
+      - uses: DataDog/action-prebuildify/prebuild@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
 
   win32-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-x64') }}
@@ -273,7 +273,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/prebuild@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
+      - uses: DataDog/action-prebuildify/prebuild@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
 
   # Tests
 
@@ -293,7 +293,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/test@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
+      - uses: DataDog/action-prebuildify/test@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
 
   centos-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -336,7 +336,7 @@ jobs:
           npm install -g yarn@^1.22.22
           dirname $(nvm which default) >> $GITHUB_PATH
         shell: bash
-      - uses: DataDog/action-prebuildify/test@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
+      - uses: DataDog/action-prebuildify/test@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
 
   linux-arm64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -351,7 +351,7 @@ jobs:
     name: linux-arm64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/test@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
+      - uses: DataDog/action-prebuildify/test@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
         with:
           node: ${{ matrix.node }}
 
@@ -368,7 +368,7 @@ jobs:
     name: linux-x64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: DataDog/action-prebuildify/test@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
+      - uses: DataDog/action-prebuildify/test@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
         with:
           node: ${{ matrix.node }}
 
@@ -414,7 +414,7 @@ jobs:
         if: ${{ matrix.node <= '14' }}
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
+      - uses: DataDog/action-prebuildify/test@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
         with:
           node: ${{ matrix.node }}
 
@@ -435,7 +435,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@c4c8dfb44e41a5a66d93256702ebea3a89556a35 # main
+      - uses: DataDog/action-prebuildify/test@79693dbe10781135699bdb1e5ab16646c2f3a43d # TEMP pin to PR branch - revert before merge
         with:
           node: ${{ matrix.node }}
 


### PR DESCRIPTION
## What

Retarget the lone macOS test job from x64 (`macos-15-intel`) to arm64 (`macos-15`). The job is renamed `darwin-x64-test` → `darwin-arm64-test` and gated on the `darwin-arm64` platform instead of `darwin-x64`.

## Why

- **The x64 macOS runners are less powerful** than their arm64 counterparts, causing CI jobs to time out and driving up flakiness.
- **macOS is primarily a developer platform**, not one used in production services — and developers overwhelmingly run arm64 laptops these days. Since we only test darwin on a single architecture, arm64 is the one that matters.

## Notes

- The `darwin-x64` **build** job is untouched — x64 prebuilds are still built and shipped, they're just no longer exercised in CI.
- We're dropping Node.js 12 and 14 as testing targets on macOS, as Node.js 16 is the first one that supports Apple Silicon. It would be possible to keep the x64 runner for these two, but I'm not sure if at this point we want to still be saddled with supporting them. This even lets us get rid of the node-gyp 9/10 switching on macOS which was also only required because of Node.js 14.