### PR TITLE
PROF-15218: Bump actions to Node.js 24 runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
       LIBC: glibc
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm32v7
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: DataDog/action-prebuildify/prebuild@52f656de95fa80939195e2b9897c032b492271b3 # main
 
   linuxglibc-arm64:
@@ -140,7 +140,7 @@ jobs:
       LIBC: glibc
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: DataDog/action-prebuildify/prebuild@52f656de95fa80939195e2b9897c032b492271b3 # main
 
   linuxglibc-ia32:
@@ -154,7 +154,7 @@ jobs:
       LIBC: glibc
       DOCKER_BUILDER: rochdev/holy-node-box:12-i386
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: DataDog/action-prebuildify/prebuild@52f656de95fa80939195e2b9897c032b492271b3 # main
 
   linuxglibc-x64:
@@ -168,7 +168,7 @@ jobs:
       LIBC: glibc
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: DataDog/action-prebuildify/prebuild@52f656de95fa80939195e2b9897c032b492271b3 # main
 
   linuxmusl-x64:
@@ -182,7 +182,7 @@ jobs:
       LIBC: musl
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64-alpine
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: DataDog/action-prebuildify/prebuild@52f656de95fa80939195e2b9897c032b492271b3 # main
 
   linuxmusl-arm64:
@@ -196,7 +196,7 @@ jobs:
       LIBC: musl
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8-alpine
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: DataDog/action-prebuildify/prebuild@52f656de95fa80939195e2b9897c032b492271b3 # main
 
   linuxmusl-x64-alpine-3-17:
@@ -211,7 +211,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-amd64-alpine-3.17
       PREBUILDS_DIR: linuxmusl-x64
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: DataDog/action-prebuildify/prebuild@52f656de95fa80939195e2b9897c032b492271b3
 
   linuxmusl-arm64-alpine-3-17:
@@ -226,7 +226,7 @@ jobs:
       DOCKER_BUILDER: rochdev/holy-node-box:12-arm64v8-alpine-3.17
       PREBUILDS_DIR: linuxmusl-arm64
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: DataDog/action-prebuildify/prebuild@52f656de95fa80939195e2b9897c032b492271b3
 
   # TODO: linuxmusl-arm
@@ -239,7 +239,7 @@ jobs:
     env:
       ARCH: arm64
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: DataDog/action-prebuildify/prebuild@52f656de95fa80939195e2b9897c032b492271b3 # main
 
   darwin-x64:
@@ -250,7 +250,7 @@ jobs:
     env:
       ARCH: x64
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: DataDog/action-prebuildify/prebuild@52f656de95fa80939195e2b9897c032b492271b3 # main
 
   win32-ia32:
@@ -261,7 +261,7 @@ jobs:
     env:
       ARCH: ia32
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: DataDog/action-prebuildify/prebuild@52f656de95fa80939195e2b9897c032b492271b3 # main
 
   win32-x64:
@@ -272,7 +272,7 @@ jobs:
     env:
       ARCH: x64
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: DataDog/action-prebuildify/prebuild@52f656de95fa80939195e2b9897c032b492271b3 # main
 
   # Tests
@@ -292,7 +292,7 @@ jobs:
     name: alpine-test-${{ matrix.node }}
     steps:
       - run: apk update && apk add bash build-base git python3 curl
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: DataDog/action-prebuildify/test@52f656de95fa80939195e2b9897c032b492271b3 # main
 
   centos-test:
@@ -318,7 +318,7 @@ jobs:
           done
           yum -y install libatomic
           echo "libatomic installed successfully."
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - name: Install Node for tests
         run: |
           curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
@@ -341,7 +341,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     name: linux-arm64-test-${{ matrix.node }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: DataDog/action-prebuildify/test@52f656de95fa80939195e2b9897c032b492271b3 # main
         with:
           node: ${{ matrix.node }}
@@ -358,7 +358,7 @@ jobs:
     runs-on: ubuntu-latest
     name: linux-x64-test-${{ matrix.node }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: DataDog/action-prebuildify/test@52f656de95fa80939195e2b9897c032b492271b3 # main
         with:
           node: ${{ matrix.node }}
@@ -375,8 +375,8 @@ jobs:
     runs-on: macos-15
     name: darwin-arm64-test-${{ matrix.node }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
@@ -405,8 +405,8 @@ jobs:
     runs-on: windows-2022
     name: win32-test-${{ matrix.node }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
@@ -438,7 +438,7 @@ jobs:
     runs-on: ubuntu-latest
     name: prebuilds
     steps:
-      - uses: actions/upload-artifact/merge@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact/merge@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: prebuilds
           pattern: prebuilds-*

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -13,7 +13,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       - run: yarn install
       - run: yarn lint

--- a/node/18/action.yml
+++ b/node/18/action.yml
@@ -2,7 +2,7 @@ name: Node 18
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v5
       with:
         node-version: '18'
         cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}

--- a/node/20/action.yml
+++ b/node/20/action.yml
@@ -2,7 +2,7 @@ name: Node 20
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v5
       with:
         node-version: '20'
         cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}

--- a/prebuild/action.yml
+++ b/prebuild/action.yml
@@ -2,7 +2,7 @@ runs:
   using: composite
   steps:
     # Make artifacts previously uploaded by the parent workflow available to binding.gyp
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v7
     - run: |
         $PACKAGE_MANAGER install --ignore-scripts
       shell: bash
@@ -18,7 +18,7 @@ runs:
     - name: Restore node headers
       if: ${{ env.GYP == 'true' && env.CACHE == 'true' }}
       id: cache-node-headers
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ env.NODE_HEADERS_DIRECTORY }}
         key: node-headers-cache-${{ runner.os }}-version${{ env.NODE_VERSIONS }}-${{ steps.compute-node-targets-hash.outputs.hash }}
@@ -29,7 +29,7 @@ runs:
       shell: bash
     - name: Save node headers
       if: ${{ env.GYP == 'true' && env.CACHE == 'true' && steps.cache-node-headers.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v5
       with:
         path: ${{ env.NODE_HEADERS_DIRECTORY }}
         key: ${{ steps.cache-node-headers.outputs.cache-primary-key }}
@@ -60,13 +60,13 @@ runs:
           /bin/bash -c '(command -v apk >/dev/null && apk add --no-cache autoconf automake libtool) || true; yarn && cd /usr/workspace && yarn exec node /usr/action'
       if: ${{ env.DOCKER_BUILDER != '' }}
       shell: bash
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: prebuilds-${{ github.job }}
         if-no-files-found: ignore
         path: ${{ env.DIRECTORY_PATH }}/prebuilds/**/${{ env.PREBUILDS_DIR || github.job }}/*
       if: ${{ env.NODE_GYP_BUILD_MAJOR != '4' }}
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: prebuilds-${{ github.job }}
         if-no-files-found: ignore

--- a/test/action.yml
+++ b/test/action.yml
@@ -6,16 +6,17 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v7
       with:
-        path: ${{ env.DIRECTORY_PATH }}
+        name: prebuilds
+        path: ${{ env.DIRECTORY_PATH }}/prebuilds
     - run: chmod -R +x ./prebuilds
       shell: bash
       working-directory: ${{ env.DIRECTORY_PATH }}
     - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       if: ${{ env.NAPI_RS == 'true' || env.RUST == 'true' }}
       shell: bash
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v5
       if: ${{ inputs.node != '' }}
       with:
         node-version: ${{ inputs.node }}


### PR DESCRIPTION
## What

Bumps the GitHub Actions used by this action to the minimum major version that runs on the **Node.js 24** runtime:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v5 |
| `actions/setup-node` | v4 | v5 |
| `actions/cache` | v3 / v4 | v5 |
| `actions/download-artifact` | v4 | v7 |
| `actions/upload-artifact` | v4 | v6 |

## Why

GitHub is deprecating the Node.js 20 runtime for Actions. Projects consuming `action-prebuildify` were getting warnings like:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout`, `actions/download-artifact`, `actions/setup-node`, `actions/upload-artifact`.

See the changelog: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Each action was bumped to the lowest major that ships `runs.using: node24`, to minimize behavioral change.

## Behavioral fix: artifact download path

Bumping `download-artifact` surfaced a behavior change: a **nameless** download of a **single** artifact now extracts directly into `path`, whereas v4 nested it in a subdirectory named after the artifact. The `test` action relied on that nesting (`chmod -R +x ./prebuilds`), so it now downloads explicitly by `name: prebuilds` into `path: <dir>/prebuilds`, which is version-independent. (The only other documented v4→v7 breaking change — the v5 path fix — applies solely to downloads *by ID*, which this action never does.)

## Depends on #135

Rebased on top of #135 (drop Node < 18). That PR removed the legacy CentOS 7 / old-Alpine test jobs, which could not run the Node 24 runtime — so this bump runs fully green across the 18+ matrix, with no container workaround needed.

## Validation

Validated fully green with the repo's `DataDog/action-prebuildify/*` self-references **temporarily pinned to this branch** (commit `72a2518`), so CI exercised the bumped composite actions:

- [Test](https://github.com/DataDog/action-prebuildify/actions/runs/28009751541)
- [Test (Neon)](https://github.com/DataDog/action-prebuildify/actions/runs/28009751552)
- [Test (Node-API)](https://github.com/DataDog/action-prebuildify/actions/runs/28009751571)
- [Project](https://github.com/DataDog/action-prebuildify/actions/runs/28009751440)

That temporary pin has since been removed; the self-references point to the current `main` SHA (`52f656d`). After merge, re-pin them to the new `main` SHA in the usual follow-up ("Pin action self-references to latest main").

Jira: [PROF-15218]