### PR TITLE
PROF-15218: Drop support for Node.js versions prior to 18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ on:
         type: string
       min-node-version:
         description: The minimum Node.js version to build and test
-        default: 12
+        default: 18
         required: false
         type: number
       node-gyp-build-major:
@@ -306,10 +306,7 @@ jobs:
       - platforms
     runs-on: ubuntu-latest
     container:
-      image: centos:${{ matrix.node < 18 && '7' || '8' }}
-      volumes:
-        - /node20217:/node20217:rw,rshared
-        - /node20217:/__e/node20:ro,rshared
+      image: centos:8
     name: centos-test-${{ matrix.node }}
     steps:
       - name: Install libatomic for Node 25+ - CentOS 8 vault repos (EOL)
@@ -321,18 +318,12 @@ jobs:
           done
           yum -y install libatomic
           echo "libatomic installed successfully."
-      # https://github.com/actions/runner/issues/2906#issuecomment-2109514798
-      - name: Install Node for runner (CentOS-compatible)
-        run: |
-          curl -LO https://unofficial-builds.nodejs.org/download/release/v20.9.0/node-v20.9.0-linux-x64-glibc-217.tar.xz
-          tar -xf node-v20.9.0-linux-x64-glibc-217.tar.xz --strip-components 1 -C /node20217
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install Node for tests
         run: |
           curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
           . $HOME/.nvm/nvm.sh
           nvm install ${{ matrix.node }}
-          npm install -g npm@^7.24.2
           npm install -g yarn@^1.22.22
           dirname $(nvm which default) >> $GITHUB_PATH
         shell: bash
@@ -377,11 +368,6 @@ jobs:
     strategy:
       matrix:
         node: ${{ fromJson(needs.versions.outputs.versions) }}
-        # Node.js < 16 has no official macOS arm64 build (Apple Silicon
-        # support landed in Node 16), so setup-node cannot install them here.
-        exclude:
-          - node: 12
-          - node: 14
     needs:
       - versions
       - prebuilds
@@ -396,10 +382,8 @@ jobs:
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
 
       #########################################################################
-      # node-gyp < 10 is not compatible with python 3.12, so for node 16+ we
-      # install node-gyp@latest. (Node 12/14 are excluded from this job above,
-      # as they have no macOS arm64 build.)
-      # Instruct npm to use the global version.
+      # node-gyp < 10 is not compatible with python 3.12, so we install
+      # node-gyp@latest. Instruct npm to use the global version.
       - run: |
           npm install -g node-gyp@latest
           npm explore npm/node_modules/@npmcli/run-script -g -- npm_config_global=false npm install node-gyp@latest

--- a/.github/workflows/test_napi.yml
+++ b/.github/workflows/test_napi.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     uses: ./.github/workflows/build.yml
     with:
-      min-node-version: 12
+      min-node-version: 18
       napi: true
       package-manager: npm
       directory-path: ./test/napi

--- a/.github/workflows/test_neon.yml
+++ b/.github/workflows/test_neon.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     uses: ./.github/workflows/build.yml
     with:
-      min-node-version: 14 # Neon only supports Node >=14 when using latest Rust
+      min-node-version: 18
       cache: true
       neon: true
       skip: linux-ia32

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ GitHub Actions reusable workflow to generate prebuilds for a Node native add-on.
 
 ## Usage
 
-This workflow can be used to generate Node 12 - 26 prebuilds for Linux, macOS
+This workflow can be used to generate Node 18 - 26 prebuilds for Linux, macOS
 and Windows. The prebuilds will be stored in the `prebuilds` folder which should
 be added to `.gitignore`, and can be loaded using
 [node-gyp-build](https://www.npmjs.com/package/node-gyp-build) with
@@ -21,7 +21,7 @@ jobs:
     with:
       cache: false # enable caching of dependencies based on lockfile
       directory-path: '.' # The path to the directory containing your build files, relative to the repo root.
-      min-node-version: 12 # The minimum Node.js version to build and test
+      min-node-version: 18 # The minimum Node.js version to build and test
       napi: false # generate single Node-API binary for all versions of Node
       napi-rs: false # Whether or not this build is for a napi-rs project.
       neon: false # Whether or not this build is for a Neon project.

--- a/compute-matrix/action.yml
+++ b/compute-matrix/action.yml
@@ -3,7 +3,7 @@ description: Computes matrix of Node.js versions
 inputs:
   min:
     description: The minimum Node.js version to include in the matrix
-    default: '12'
+    default: '18'
   max:
     description: The maximum Node.js version to include in the matrix
     default: '26'

--- a/compute-matrix/index.js
+++ b/compute-matrix/index.js
@@ -5,7 +5,7 @@ const { parseArgs } = require('node:util')
 const { values } = parseArgs({
   args: process.argv.slice(2),
   options: {
-    min: { type: 'string', default: '12' },
+    min: { type: 'string', default: '18' },
     max: { type: 'string', default: '26' },
     step: { type: 'string', default: '2' }
   }

--- a/node/12/action.yml
+++ b/node/12/action.yml
@@ -1,8 +1,0 @@
-name: Node 12
-runs:
-  using: composite
-  steps:
-    - uses: actions/setup-node@v4
-      with:
-        node-version: '12'
-        cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}

--- a/node/14/action.yml
+++ b/node/14/action.yml
@@ -1,8 +1,0 @@
-name: Node 14
-runs:
-  using: composite
-  steps:
-    - uses: actions/setup-node@v4
-      with:
-        node-version: '14'
-        cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}

--- a/node/16/action.yml
+++ b/node/16/action.yml
@@ -1,8 +1,0 @@
-name: Node 16
-runs:
-  using: composite
-  steps:
-    - uses: actions/setup-node@v4
-      with:
-        node-version: '16'
-        cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}

--- a/prebuild/targets.js
+++ b/prebuild/targets.js
@@ -3,12 +3,6 @@
 const semver = require('semver')
 
 const nodeTargets = [
-  { version: '12.0.0', abi: '72', alpineVersion: '~3.14' },
-  { version: '13.0.0', abi: '79', alpineVersion: '~3.14' },
-  { version: '14.0.0', abi: '83', alpineVersion: '~3.14' },
-  { version: '15.0.0', abi: '88', alpineVersion: '~3.14' },
-  { version: '16.0.0', abi: '93', alpineVersion: '~3.14' },
-  { version: '17.0.1', abi: '102', alpineVersion: '~3.14' },
   { version: '18.0.0', abi: '108', alpineVersion: '~3.14' },
   { version: '19.0.0', abi: '111', alpineVersion: '~3.14' },
   { version: '20.0.0', abi: '115', alpineVersion: '~3.14' },


### PR DESCRIPTION
## What

Drops support for Node.js versions prior to **18** across all platforms, and removes the legacy-container workarounds that only existed to test those versions.

- `compute-matrix` and the `build.yml` default: `min-node-version` `12` → `18` (matrix is now `[18, 20, 22, 24, 26]`)
- `prebuild/targets.js`: remove the Node 12–17 ABI targets (build only emits prebuilds for 18+)
- remove the `node/12`, `node/14`, `node/16` setup-node composite actions
- `centos-test`: always run on **CentOS 8** (Node 18+ never needs CentOS 7); drop the CentOS 7 branch, the glibc-217 Node 20 volume mount, and the "Install Node for runner" step
- `darwin-arm64-test`: drop the Node 12/14 `exclude` (those have no macOS arm64 build)
- `test_napi` / `test_neon` callers: `min-node-version` → `18`
- README: documents Node 18 – 26

## Why

Node 12/14/16 (and the odd 13/15/17) are end-of-life. Beyond simplifying the support matrix and reducing user confusion, they're the reason CI has been red on `main`: GitHub force-runs Actions on Node 24, which **cannot execute** in the legacy containers those versions require — CentOS 7 (glibc too old) and old Alpine (musl 1.2.2 lacks `pthread_getname_np`). Node 18+ runs on CentOS 8 / modern Alpine, which host Node 24 fine.

Removing the old versions therefore **restores a green `main`** and clears the way to bump the actions to the Node 24 runtime (separate PR, to be rebased on top of this).

## Verification

- `compute-matrix` → `[18,20,22,24,26]`
- `getFilteredNodeTargets('>=18')` → 18–26 only
- `node test/naming.js` passes; `yarn lint` clean
