### PR TITLE
Pin action self-references to latest main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - id: versions
-        uses: DataDog/action-prebuildify/compute-matrix@52f656de95fa80939195e2b9897c032b492271b3 # main
+        uses: DataDog/action-prebuildify/compute-matrix@dcb3745306e1c37a4b9bf121e68c74c61c49a99a # main
         with:
           min: ${{ inputs.min-node-version }}
 
@@ -110,7 +110,7 @@ jobs:
       platforms: ${{ steps.platforms.outputs.platforms }}
     steps:
       - id: platforms
-        uses: DataDog/action-prebuildify/platforms@52f656de95fa80939195e2b9897c032b492271b3 # main
+        uses: DataDog/action-prebuildify/platforms@dcb3745306e1c37a4b9bf121e68c74c61c49a99a # main
         with:
           skip: ${{ inputs.skip }}
           only: ${{ inputs.only }}
@@ -127,7 +127,7 @@ jobs:
       DOCKER_BUILDER: ghcr.io/rochdev/holy-node-box:12-arm32v7
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - uses: DataDog/action-prebuildify/prebuild@52f656de95fa80939195e2b9897c032b492271b3 # main
+      - uses: DataDog/action-prebuildify/prebuild@dcb3745306e1c37a4b9bf121e68c74c61c49a99a # main
 
   linuxglibc-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -141,7 +141,7 @@ jobs:
       DOCKER_BUILDER: ghcr.io/rochdev/holy-node-box:12-arm64v8
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - uses: DataDog/action-prebuildify/prebuild@52f656de95fa80939195e2b9897c032b492271b3 # main
+      - uses: DataDog/action-prebuildify/prebuild@dcb3745306e1c37a4b9bf121e68c74c61c49a99a # main
 
   linuxglibc-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-ia32') }}
@@ -155,7 +155,7 @@ jobs:
       DOCKER_BUILDER: ghcr.io/rochdev/holy-node-box:12-i386
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - uses: DataDog/action-prebuildify/prebuild@52f656de95fa80939195e2b9897c032b492271b3 # main
+      - uses: DataDog/action-prebuildify/prebuild@dcb3745306e1c37a4b9bf121e68c74c61c49a99a # main
 
   linuxglibc-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -169,7 +169,7 @@ jobs:
       DOCKER_BUILDER: ghcr.io/rochdev/holy-node-box:12-amd64
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - uses: DataDog/action-prebuildify/prebuild@52f656de95fa80939195e2b9897c032b492271b3 # main
+      - uses: DataDog/action-prebuildify/prebuild@dcb3745306e1c37a4b9bf121e68c74c61c49a99a # main
 
   linuxmusl-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-x64') }}
@@ -183,7 +183,7 @@ jobs:
       DOCKER_BUILDER: ghcr.io/rochdev/holy-node-box:12-amd64-alpine
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - uses: DataDog/action-prebuildify/prebuild@52f656de95fa80939195e2b9897c032b492271b3 # main
+      - uses: DataDog/action-prebuildify/prebuild@dcb3745306e1c37a4b9bf121e68c74c61c49a99a # main
 
   linuxmusl-arm64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-arm64') }}
@@ -197,7 +197,7 @@ jobs:
       DOCKER_BUILDER: ghcr.io/rochdev/holy-node-box:12-arm64v8-alpine
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - uses: DataDog/action-prebuildify/prebuild@52f656de95fa80939195e2b9897c032b492271b3 # main
+      - uses: DataDog/action-prebuildify/prebuild@dcb3745306e1c37a4b9bf121e68c74c61c49a99a # main
 
   linuxmusl-x64-alpine-3-17:
     if: ${{ !inputs.napi && !inputs.napi-rs && !inputs.neon && !inputs.rust && contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-x64') }}
@@ -212,7 +212,7 @@ jobs:
       PREBUILDS_DIR: linuxmusl-x64
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - uses: DataDog/action-prebuildify/prebuild@52f656de95fa80939195e2b9897c032b492271b3
+      - uses: DataDog/action-prebuildify/prebuild@dcb3745306e1c37a4b9bf121e68c74c61c49a99a
 
   linuxmusl-arm64-alpine-3-17:
     if: ${{ !inputs.napi && !inputs.napi-rs && !inputs.neon && !inputs.rust && contains(fromJson(needs.platforms.outputs.platforms), 'linuxmusl-arm64') }}
@@ -227,7 +227,7 @@ jobs:
       PREBUILDS_DIR: linuxmusl-arm64
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - uses: DataDog/action-prebuildify/prebuild@52f656de95fa80939195e2b9897c032b492271b3
+      - uses: DataDog/action-prebuildify/prebuild@dcb3745306e1c37a4b9bf121e68c74c61c49a99a
 
   # TODO: linuxmusl-arm
 
@@ -240,7 +240,7 @@ jobs:
       ARCH: arm64
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - uses: DataDog/action-prebuildify/prebuild@52f656de95fa80939195e2b9897c032b492271b3 # main
+      - uses: DataDog/action-prebuildify/prebuild@dcb3745306e1c37a4b9bf121e68c74c61c49a99a # main
 
   darwin-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'darwin-x64') }}
@@ -251,7 +251,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - uses: DataDog/action-prebuildify/prebuild@52f656de95fa80939195e2b9897c032b492271b3 # main
+      - uses: DataDog/action-prebuildify/prebuild@dcb3745306e1c37a4b9bf121e68c74c61c49a99a # main
 
   win32-ia32:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-ia32') }}
@@ -262,7 +262,7 @@ jobs:
       ARCH: ia32
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - uses: DataDog/action-prebuildify/prebuild@52f656de95fa80939195e2b9897c032b492271b3 # main
+      - uses: DataDog/action-prebuildify/prebuild@dcb3745306e1c37a4b9bf121e68c74c61c49a99a # main
 
   win32-x64:
     if: ${{ contains(fromJson(needs.platforms.outputs.platforms), 'win32-x64') }}
@@ -273,7 +273,7 @@ jobs:
       ARCH: x64
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - uses: DataDog/action-prebuildify/prebuild@52f656de95fa80939195e2b9897c032b492271b3 # main
+      - uses: DataDog/action-prebuildify/prebuild@dcb3745306e1c37a4b9bf121e68c74c61c49a99a # main
 
   # Tests
 
@@ -293,7 +293,7 @@ jobs:
     steps:
       - run: apk update && apk add bash build-base git python3 curl
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - uses: DataDog/action-prebuildify/test@52f656de95fa80939195e2b9897c032b492271b3 # main
+      - uses: DataDog/action-prebuildify/test@dcb3745306e1c37a4b9bf121e68c74c61c49a99a # main
 
   centos-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-x64') }}
@@ -327,7 +327,7 @@ jobs:
           npm install -g yarn@^1.22.22
           dirname $(nvm which default) >> $GITHUB_PATH
         shell: bash
-      - uses: DataDog/action-prebuildify/test@52f656de95fa80939195e2b9897c032b492271b3 # main
+      - uses: DataDog/action-prebuildify/test@dcb3745306e1c37a4b9bf121e68c74c61c49a99a # main
 
   linux-arm64-test:
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.platforms.outputs.platforms), 'linuxglibc-arm64') }}
@@ -342,7 +342,7 @@ jobs:
     name: linux-arm64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - uses: DataDog/action-prebuildify/test@52f656de95fa80939195e2b9897c032b492271b3 # main
+      - uses: DataDog/action-prebuildify/test@dcb3745306e1c37a4b9bf121e68c74c61c49a99a # main
         with:
           node: ${{ matrix.node }}
 
@@ -359,7 +359,7 @@ jobs:
     name: linux-x64-test-${{ matrix.node }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - uses: DataDog/action-prebuildify/test@52f656de95fa80939195e2b9897c032b492271b3 # main
+      - uses: DataDog/action-prebuildify/test@dcb3745306e1c37a4b9bf121e68c74c61c49a99a # main
         with:
           node: ${{ matrix.node }}
 
@@ -389,7 +389,7 @@ jobs:
           npm explore npm/node_modules/@npmcli/run-script -g -- npm_config_global=false npm install node-gyp@latest
       #########################################################################
 
-      - uses: DataDog/action-prebuildify/test@52f656de95fa80939195e2b9897c032b492271b3 # main
+      - uses: DataDog/action-prebuildify/test@dcb3745306e1c37a4b9bf121e68c74c61c49a99a # main
         with:
           node: ${{ matrix.node }}
 
@@ -410,7 +410,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ (env.CACHE == 'true') && env.PACKAGE_MANAGER || '' }}
-      - uses: DataDog/action-prebuildify/test@52f656de95fa80939195e2b9897c032b492271b3 # main
+      - uses: DataDog/action-prebuildify/test@dcb3745306e1c37a4b9bf121e68c74c61c49a99a # main
         with:
           node: ${{ matrix.node }}
 


### PR DESCRIPTION
## What

Re-pins the repo's own `DataDog/action-prebuildify/*` self-references in the reusable `build.yml` from `52f656d` to the current `main` SHA `dcb3745`.

| Reference | Before | After |
|---|---|---|
| `compute-matrix` | `52f656d` | `dcb3745` |
| `platforms` | `52f656d` | `dcb3745` |
| `prebuild` (all platform jobs) | `52f656d` | `dcb3745` |

## Why

The self-references were lagging at `52f656d` — i.e. before the Node 24 actions bump (#134) and the Node < 18 drop (#135). Re-pinning to the latest `main` ensures the reusable workflow's `compute-matrix`, `platforms`, and `prebuild` composite actions run the current code. This is the standard follow-up after merging changes to those composite actions (cf. #128, #132).
